### PR TITLE
Add a keybinding to the commit view to easily sign off commits

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -11,6 +11,13 @@
             { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["super+s"],
+        "command": "gs_commit_view_sign",
+        "context": [
+            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+        ]
+    },
 
     ///////////////
     // DIFF VIEW //

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -11,6 +11,13 @@
             { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["super+s"],
+        "command": "gs_commit_view_sign",
+        "context": [
+            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+        ]
+    },
 
     ///////////////
     // DIFF VIEW //

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -11,6 +11,13 @@
             { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["ctrl+s"],
+        "command": "gs_commit_view_sign",
+        "context": [
+            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+        ]
+    },
 
 
     ///////////////

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -17,6 +17,11 @@ COMMIT_HELP_TEXT = """
 ## key to reference an issue in a different GitHub repo.
 """.format(key="CTRL" if os.name == "nt" else "SUPER")
 
+COMMIT_SIGN_TEXT = """
+
+Signed-off-by: {name} <{email}>
+"""
+
 COMMIT_TITLE = "COMMIT"
 
 
@@ -92,3 +97,26 @@ class GsCommitViewDoCommitCommand(TextCommand, GitCommand):
 
         self.view.window().focus_view(self.view)
         self.view.window().run_command("close_file")
+
+
+class GsCommitViewSignCommand(TextCommand, GitCommand):
+
+    """
+    Sign off the commit with full name and email
+    """
+
+    def run(self, edit):
+        view_text = self.view.substr(sublime.Region(0, self.view.size()))
+        view_text_list = view_text.split(COMMIT_HELP_TEXT)
+
+        config_name = self.git("config", "user.name").strip()
+        config_email = self.git("config", "user.email").strip()
+
+        sign_text = COMMIT_SIGN_TEXT.format(name=config_name, email=config_email)
+        view_text_list[0] += sign_text
+        view_text_list.insert(1, COMMIT_HELP_TEXT)
+
+        self.view.run_command("gs_replace_view_text", {
+            "text": "".join(view_text_list),
+            "nuke_cursors": True
+            })

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -114,9 +114,8 @@ class GsCommitViewSignCommand(TextCommand, GitCommand):
 
         sign_text = COMMIT_SIGN_TEXT.format(name=config_name, email=config_email)
         view_text_list[0] += sign_text
-        view_text_list.insert(1, COMMIT_HELP_TEXT)
 
         self.view.run_command("gs_replace_view_text", {
-            "text": "".join(view_text_list),
+            "text": COMMIT_HELP_TEXT.join(view_text_list),
             "nuke_cursors": True
             })

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -9,7 +9,7 @@ from ..git_command import GitCommand
 COMMIT_HELP_TEXT = """
 
 ## To make a commit, type your commit message and press {key}-ENTER. To cancel
-## the commit, close the window.
+## the commit, close the window. To sign off the commit press {key}-S.
 
 ## You may also reference or close a GitHub issue with this commit.  To do so,
 ## type `#` followed by the `tab` key.  You will be shown a list of issues


### PR DESCRIPTION
Partial fix for #36, this will sign-off commits by hitting <kbd>Super</kbd>+<kbd>s</kbd>.

As with my previous PR, this will need proof-checking, I'm still quite new to Python.