### PR TITLE
Conditional check if remote url ends with .git

### DIFF
--- a/github/github.py
+++ b/github/github.py
@@ -24,10 +24,13 @@ def parse_remote(remote):
     an object with original url, FQDN, owner, repo, and the token to use for
     this particular FQDN (if available).
     """
+    if remote.endswith(".git"):
+        remote = remote[:-4]
+        
     if remote.startswith("git@"):
-        url = remote.replace(":", "/").replace("git@", "http://")[:-4]
+        url = remote.replace(":", "/").replace("git@", "http://")
     elif remote.startswith("http"):
-        url = remote[:-4]
+        url = remote
     else:
         return None
 


### PR DESCRIPTION
github integration doesn't work with remote urls that to not end on ".git".

users like me who tend to clone repos by just copy and pasting the address line out of the browser into the terminal would be affected by this issue.