### PR TITLE
Avoid empty sublime.Region for removed newline. Closes #61.

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -264,8 +264,7 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
                     region_type = line_type
                     region_start = line.begin()
                 elif region_type != line_type:
-                    # End region with final character of previous line.
-                    region_end = line.begin() - 1
+                    region_end = line.begin()
                     l = add_regions if region_type == "+" else remove_regions
                     l.append(sublime.Region(region_start, region_end))
 


### PR DESCRIPTION
Check out this fix when you have a chance. Not sure what necessitated the region-end as you had it before, but this seems to work for several different types of diffs I tested....