### PR TITLE
Don't lock up the panels/inputs while pushing

### DIFF
--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -10,26 +10,27 @@ START_PUSH_MESSAGE = "Starting push..."
 END_PUSH_MESSAGE = "Push complete."
 PUSH_TO_BRANCH_NAME_PROMPT = "Enter remote branch name:"
 
-def do_push(self, remote, branch):
-    """
-    Perform `git push remote branch`.
-    """
-    sublime.status_message(START_PUSH_MESSAGE)
-    self.push(remote, branch)
-    sublime.status_message(END_PUSH_MESSAGE)
-    util.view.refresh_gitsavvy(self.window.active_view())
+class PushBase(GitCommand):
+    def do_push(self, remote, branch):
+        """
+        Perform `git push remote branch`.
+        """
+        sublime.status_message(START_PUSH_MESSAGE)
+        self.push(remote, branch)
+        sublime.status_message(END_PUSH_MESSAGE)
+        util.view.refresh_gitsavvy(self.window.active_view())
 
-class GsPushCommand(WindowCommand, GitCommand):
+class GsPushCommand(WindowCommand, PushBase):
 
     """
     Perform a normal `git push`.
     """
 
     def run(self):
-        sublime.set_timeout_async(lambda: do_push(self, None, None))
+        sublime.set_timeout_async(lambda: self.do_push(None, None))
 
 
-class GsPushToBranchCommand(WindowCommand, GitCommand):
+class GsPushToBranchCommand(WindowCommand, PushBase):
 
     """
     Through a series of panels, allow the user to push to a specific remote branch.
@@ -101,9 +102,9 @@ class GsPushToBranchCommand(WindowCommand, GitCommand):
             return
 
         selected_branch = self.branches_on_selected_remote[branch_index].split("/", 1)[1]
-        sublime.set_timeout_async(lambda: do_push(self, self.selected_remote, selected_branch))
+        sublime.set_timeout_async(lambda: self.do_push(self.selected_remote, selected_branch))
 
-class GsPushToBranchNameCommand(WindowCommand, GitCommand):
+class GsPushToBranchNameCommand(WindowCommand, PushBase):
 
     """
     Prompt for remote and remote branch name, then push.
@@ -154,4 +155,4 @@ class GsPushToBranchNameCommand(WindowCommand, GitCommand):
         Push to the remote that was previously selected and provided branch
         name.
         """
-        sublime.set_timeout_async(lambda: do_push(self, self.selected_remote, branch))
+        sublime.set_timeout_async(lambda: self.do_push(self.selected_remote, branch))

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -9,6 +9,16 @@ START_PUSH_MESSAGE = "Starting push..."
 END_PUSH_MESSAGE = "Push complete."
 PUSH_TO_BRANCH_NAME_PROMPT = "Enter remote branch name:"
 
+def do_push(self, remote, branch):
+    """
+    Perform `git push remote branch`.
+    """
+    sublime.status_message(START_PUSH_MESSAGE)
+    self.push(remote, branch)
+    sublime.status_message(END_PUSH_MESSAGE)
+    if self.window.active_view().settings().get("git_savvy.status_view"):
+        self.window.active_view().run_command("gs_status_refresh")
+
 class GsPushCommand(WindowCommand, GitCommand):
 
     """
@@ -16,14 +26,7 @@ class GsPushCommand(WindowCommand, GitCommand):
     """
 
     def run(self):
-        sublime.set_timeout_async(lambda: self.do_push())
-
-    def do_push(self):
-        sublime.status_message(START_PUSH_MESSAGE)
-        self.push(remote=None, branch=None)
-        sublime.status_message(END_PUSH_MESSAGE)
-        if self.window.active_view().settings().get("git_savvy.status_view"):
-            self.window.active_view().run_command("gs_status_refresh")
+        sublime.set_timeout_async(lambda: do_push(self, None, None))
 
 
 class GsPushToBranchCommand(WindowCommand, GitCommand):
@@ -98,18 +101,7 @@ class GsPushToBranchCommand(WindowCommand, GitCommand):
             return
 
         selected_branch = self.branches_on_selected_remote[branch_index].split("/", 1)[1]
-        sublime.set_timeout_async(lambda: self.do_push(self.selected_remote, selected_branch))
-
-    def do_push(self, remote, branch):
-        """
-        Perform `git push remote branch`.
-        """
-        sublime.status_message(START_PUSH_MESSAGE)
-        self.push(remote, branch)
-        sublime.status_message(END_PUSH_MESSAGE)
-        if self.window.active_view().settings().get("git_savvy.status_view"):
-            self.window.active_view().run_command("gs_status_refresh")
-
+        sublime.set_timeout_async(lambda: do_push(self, self.selected_remote, selected_branch))
 
 class GsPushToBranchNameCommand(WindowCommand, GitCommand):
 
@@ -162,8 +154,6 @@ class GsPushToBranchNameCommand(WindowCommand, GitCommand):
         Push to the remote that was previously selected and provided branch
         name.
         """
-        sublime.status_message(START_PUSH_MESSAGE)
-        self.push(self.selected_remote, branch)
-        sublime.status_message(END_PUSH_MESSAGE)
+        sublime.set_timeout_async(lambda: do_push(self, self.selected_remote, branch))
         if self.window.active_view().settings().get("git_savvy.status_view"):
             self.window.active_view().run_command("gs_status_refresh")

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -122,7 +122,7 @@ class GsPushToBranchNameCommand(WindowCommand, GitCommand):
         self.remote_branches = self.get_remote_branches()
 
         if not self.remotes:
-            self.window.show_quick_panel(["There are no remotes available."], None)
+            self.window.show_quick_panel([NO_REMOTES_MESSAGE], None)
         else:
             self.window.show_quick_panel(
                 self.remotes,


### PR DESCRIPTION
I moved `do_push` outside of the classes (since they all use something like this) and turned all calls of it (and `self.push`) into calling it asynchronously.

I was thinking of moving it even further away (maybe into the mixins) since other files might make use of it as well. And while on that train of thought I was also thinking of maybe moving every occurrence of the following block of code just the same.

```Python
self.remotes = list(self.get_remotes().keys())

if not self.remotes:
    self.window.show_quick_panel([NO_REMOTES_MESSAGE], None)
else:
    self.window.show_quick_panel(
        self.remotes,
        self.on_select_remote,
        flags=sublime.MONOSPACE_FONT
        )
``` 