### PR TITLE
Adding head SHA1 and abbreviated commit msg to status view

### DIFF
--- a/core/commands/status.py
+++ b/core/commands/status.py
@@ -42,6 +42,7 @@ STASHES_TEMPLATE = """
 STATUS_HEADER_TEMPLATE = """
   BRANCH:  {branch_status}
   ROOT:    {repo_root}
+  HEAD:    {current_head}
 """
 
 NO_STATUS_MESSAGE = """
@@ -130,7 +131,8 @@ class GsStatusRefreshCommand(TextCommand, GitCommand):
         """
         header = STATUS_HEADER_TEMPLATE.format(
             branch_status=self.get_branch_status(),
-            repo_root=self.repo_path
+            repo_root=self.repo_path,
+            current_head=self.get_latest_commit_msg_for_head()
         )
 
         cursor = len(header)

--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -64,3 +64,9 @@ class ActiveBranchMixin():
         Get the SHA1 commit hash for the commit at HEAD.
         """
         return self.git("rev-parse", "HEAD").strip()
+
+    def get_latest_commit_msg_for_head(self):
+        """
+        Get last commit msg for the commit at HEAD.
+        """
+        return self.git("log", "-n 1", "--pretty=format:%h %s", "--abbrev-commit").strip()

--- a/syntax/status.YAML-tmLanguage
+++ b/syntax/status.YAML-tmLanguage
@@ -13,13 +13,19 @@ patterns:
   patterns:
   - comment: root summary
     name: comment.git-savvy.status.root-summary
-    match: '^  ROOT:.+'
+    match: '^  ROOT:.+' 
   - comment: branch names
     name: constant.other.git-savvy.status.branch-name
     match: '`[A-Za-z\-_/]+`'
   - comment: ahead or behind
     name: keyword.other.git-savvy.status.ahead-behind
     match: '(ahead)|(behind)'
+  - comment: head summary
+    name: comment.git-savvy.status.head-commit
+    match: '^  HEAD:'
+  - comment: head commit sha1
+    name: constant.other.git-savvy.status.sha1
+    match: '    (([0-9]|[A-Z]){7}) '
 
 - comment: section
   name: meta.git-savvy.status.section

--- a/syntax/status.tmLanguage
+++ b/syntax/status.tmLanguage
@@ -49,6 +49,22 @@
 					<key>name</key>
 					<string>keyword.other.git-savvy.status.ahead-behind</string>
 				</dict>
+				<dict>
+					<key>comment</key>
+					<string>head commit message</string>
+					<key>match</key>
+					<string>^  HEAD:</string>
+					<key>name</key>
+					<string>comment.git-savvy.status.head-commit</string>
+				</dict>	
+				<dict>
+					<key>comment</key>
+					<string>head commit sha1</string>
+					<key>match</key>
+					<string>    (([0-9]|[A-Za-z]){7}) </string>
+					<key>name</key>
+					<string>constant.other.git-savvy.status.sha1</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
Switching to GitSavvy from SublimeGit one small feature I and possibly others might find useful to is having a quick reference to the HEAD current commit SHA1 and commit msg as part of the status view. I find this handy for info about the most recent commit as well as when I am cherry picking the latest commit I can easily grab the SHA1 I'll be cherry picking before switching branches to do so.