### PR TITLE
Add `--all` to graph command to show other branches (esp. origin)

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -26,5 +26,5 @@ class GsLogGraphCommand(WindowCommand, GitCommand):
 class GsLogGraphInitializeCommand(TextCommand, GitCommand):
 
     def run(self, edit):
-        branch_graph = self.git("log", "--oneline", "--graph", "--decorate")
+        branch_graph = self.git("log", "--oneline", "--graph", "--all", "--decorate")
         self.view.run_command("gs_replace_view_text", {"text": branch_graph})


### PR DESCRIPTION
Add `--all` to `graph` log command so that other branches become visible.

This is helpful in branched workflow (e.g. git-flow) where after a pull on master one needs to see how feature branches have diverged.

Screenshot:

![gitsavvy graph-all](https://cloud.githubusercontent.com/assets/103215/6686804/7ecdd7ee-ccad-11e4-9f66-30f8b9291cfc.png)
