### PR TITLE
Scroll to first diff (inline)

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -25,6 +25,12 @@
      */
     "show_commit_diff": false,
 
+    /*
+        Change this to `true` to scroll to the first hunk automatically when
+        you open the inline-diff view.
+     */
+    "inline_diff_auto_scoll": false,
+
     "colors": {
         /*
             Colors used by the inline-diff view to display changes.

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -141,10 +141,13 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
         self.view.replace(edit, sublime.Region(0, self.view.size()), inline_diff_contents)
 
         if cursors:
-            self.view.sel().clear()
-            pt = self.view.text_point(row, 0)
-            self.view.sel().add(sublime.Region(pt, pt))
-            self.view.show_at_center(pt)
+            if (row, col) == (0, 0) and sublime.load_settings("GitSavvy.sublime-settings").get("inline_diff_auto_scoll", False):
+                self.view.run_command("gs_inline_diff_goto_next_hunk")
+            else:
+                self.view.sel().clear()
+                pt = self.view.text_point(row, 0)
+                self.view.sel().add(sublime.Region(pt, pt))
+                self.view.show_at_center(pt)
 
         self.highlight_regions(replaced_lines)
         self.view.set_read_only(True)
@@ -289,16 +292,6 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
 
         self.view.add_regions("git-better-added-lines", add_regions, scope="git_savvy.change.addition")
         self.view.add_regions("git-better-removed-lines", remove_regions, scope="git_savvy.change.removal")
-        self.scroll_to_the_first_change(l)
-        
-    def scroll_to_the_first_change(self, regions):
-        cursors = self.view.sel()
-        if regions and cursors[0].begin() == 0:
-            region_beginning = regions[0].begin()
-            first_change = sublime.Region(region_beginning, region_beginning)
-            cursors.clear()
-            cursors.add(first_change)
-            self.view.show(first_change)
 
     def verify_not_conflict(self):
         fpath = self.get_rel_path()

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -287,13 +287,18 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
             l = add_regions if region_type == "+" else remove_regions
             l.append(sublime.Region(region_start, region_end))
 
-        self.scroll_to_the_first_change(l)
         self.view.add_regions("git-better-added-lines", add_regions, scope="git_savvy.change.addition")
         self.view.add_regions("git-better-removed-lines", remove_regions, scope="git_savvy.change.removal")
-
+        self.scroll_to_the_first_change(l)
+        
     def scroll_to_the_first_change(self, regions):
-        if regions:
-            self.view.set_viewport_position((regions[0].begin(), regions[0].end()), True)
+        cursors = self.view.sel()
+        if regions and cursors[0].begin() == 0:
+            region_beginning = regions[0].begin()
+            first_change = sublime.Region(region_beginning, region_beginning)
+            cursors.clear()
+            cursors.add(first_change)
+            self.view.show(first_change)
 
     def verify_not_conflict(self):
         fpath = self.get_rel_path()

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -287,8 +287,13 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
             l = add_regions if region_type == "+" else remove_regions
             l.append(sublime.Region(region_start, region_end))
 
+        self.scroll_to_the_first_change(l)
         self.view.add_regions("git-better-added-lines", add_regions, scope="git_savvy.change.addition")
         self.view.add_regions("git-better-removed-lines", remove_regions, scope="git_savvy.change.removal")
+
+    def scroll_to_the_first_change(self, regions):
+        if regions:
+            self.view.set_viewport_position((regions[0].begin(), regions[0].end()), True)
 
     def verify_not_conflict(self):
         fpath = self.get_rel_path()

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -4,7 +4,7 @@
 
 Running this command will open a special "Inline Diff" view related to the open file.  All changes made to the file will be displayed inline; removed lines are displayed in red, and added lines are displayed in green.  All other lines are displayed as normal, with full syntax highlighting.
 
-While in this view, you can navigate between changed hunks using the `,` and `.` keys.  `,` will take you to the previous hunk and `.` will take you to the next hunk.
+While in this view, you can navigate between changed hunks using the `,` and `.` keys.  `,` will take you to the previous hunk and `.` will take you to the next hunk. If you have the `inline_diff_auto_scoll` setting set to `true`, the cursor will be automatically placed on the first hunk when the view is opened.
 
 While the cursor is positioned at a hunk, you can stage that hunk by pressing `h`.  If you'd like to stage a line only, and _not_ the full hunk, move the cursor to the desired line and press `l` (lower-case L).
 


### PR DESCRIPTION
Hello again!
This PR makes GitSavvy automatically scroll to the first found diff on the file:

**before**
![before](https://cloud.githubusercontent.com/assets/692077/6765802/d2e58b2e-cfcd-11e4-8e45-898a79b0926f.gif)

**after**
![after](https://cloud.githubusercontent.com/assets/692077/6765801/d091812a-cfcd-11e4-9e84-d9e0487d72b2.gif)


I don't know if this is a something you had in mind for the package but I find it very useful.

Let me know if you need me to change anything,
Thanks!