### PR TITLE
Add an option to append customized message to the default commit help.

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -83,6 +83,16 @@
     "default_tag_message": "Tag {tag_name}",
 
     /*
+        The filename for extra customized info to be displayed after the default
+        COMMIT_HELP_TEXT, such as commit message rules/tips/conventions.
+        Place this file at the root of the repo, and it should be commited to the
+        repo as well.
+        The file name defaults to `.commit_help`.
+        If this file is not presented, the functionality is totally ignored.
+     */
+    "commit_help_extra_file": ".commit_help",
+
+    /*
         For each command specified, always include the command line flags
         indicated in the global_flags hash.
      */

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -68,6 +68,7 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
 
     def run(self, edit):
         merge_msg_path = os.path.join(self.repo_path, ".git", "MERGE_MSG")
+        gitsavvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
 
         option_amend = self.view.settings().get("git_savvy.commit_view.amend")
         if option_amend:
@@ -79,7 +80,13 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
         else:
             initial_text = COMMIT_HELP_TEXT
 
-        if sublime.load_settings("GitSavvy.sublime-settings").get("show_commit_diff"):
+        commit_help_extra_file = gitsavvy_settings.get("commit_help_extra_file") or ".commit_help"
+        commit_help_extra_path = os.path.join(self.repo_path, commit_help_extra_file)
+        if os.path.exists(commit_help_extra_path):
+            with open(commit_help_extra_path, "r", encoding="utf-8") as f:
+                initial_text += f.read()
+
+        if gitsavvy_settings.get("show_commit_diff"):
             if option_amend:
                 initial_text += self.git("diff", "HEAD^")
             else:


### PR DESCRIPTION
So that one can display a commit rule/tip/convention to the team when they commit, something like this:
![image](https://cloud.githubusercontent.com/assets/536624/7197045/816009f4-e50e-11e4-8194-cefb6e8f2ac9.png)
