### PR TITLE
fix: BranchesMixin regex doesn't match branch names with dots

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -30,7 +30,7 @@ class BranchesMixin():
         if not line:
             return None
 
-        pattern = r"(\* )?(remotes/)?([a-zA-Z0-9\-\_\/\\]+) +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\\]+)(: ([^\]]+))?\] )?(.*)"
+        pattern = r"(\* )?(remotes/)?([a-zA-Z0-9\.\-\_\/\\]+) +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\\]+)(: ([^\]]+))?\] )?(.*)"
         r"((: ))?"
 
         match = re.match(pattern, line)


### PR DESCRIPTION
Existing regex didn't match branch names like 'v1.1' or 'release/v1.1'. If you checkout or create a branch with `.` in the name, it will display correctly as the active branch, but won't appear in the list of local or remote branches:

![screen shot 2015-05-01 at 16 48 40](https://cloud.githubusercontent.com/assets/912471/7432696/2b21a768-f022-11e4-9a5a-66629e5ad7f7.png)


