### PR TITLE
fix: get_branch_status_short should unpack gone value

### DIFF
--- a/core/git_mixins/active_branch.py
+++ b/core/git_mixins/active_branch.py
@@ -95,7 +95,7 @@ class ActiveBranchMixin():
         return status, secondary
 
     def get_branch_status_short(self):
-        detached, initial, branch, remote, clean, ahead, behind = \
+        detached, initial, branch, remote, clean, ahead, behind, gone = \
             self._get_branch_status_components()
 
         dirty = "" if clean else "*"


### PR DESCRIPTION
In my previous commit 6b5fd98c `_get_branch_status_components` was updated to return a seventh value (boolean indicating if the remote branch was gone), but `get_branch_status_short` wasn't updated to unpack this value.

Sorry, I really should have checked for additional calls to `get_branch_status_short`!