### PR TITLE
feature: per-project default rebase base ref

### DIFF
--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -212,8 +212,9 @@ class RebaseInterface(ui.Interface, GitCommand):
     def base_ref(self):
         base_ref = self.view.settings().get("git_savvy.rebase.base_ref")
         if not base_ref:
-            base_ref = "master"
-            self.view.settings().set("git_savvy.revase.base_ref", "master")
+            project_settings = sublime.active_window().project_data().get('settings', {})
+            base_ref = project_settings.get("rebase_default_base_ref", "master")
+            self.view.settings().set("git_savvy.rebase.base_ref", base_ref)
         return base_ref
 
     def base_commit(self):

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -62,7 +62,20 @@ This will display the selected commit data and meta-data in a new window, includ
 
 When initially opening the rebase dashboard, GitSavvy will attempt to determine the root commit of the branch, i.e. the HEAD when you typed `git checkout -b BRANCH_NAME`.  This commit is used as the starting point for the information that is displayed.
 
-In most cases, this will default to `master`.  However, if you would like to compare the current branch against something other than local `master`, using this command will allow you to make that selection.
+In most cases, this will default to `master`.  However, if you would like to compare the current branch against something other than local `master`, using this command will allow you to make that selection. You can override the default per-project by adding a `rebase_default_base_ref` to your `.sublime-project` file:
+
+```json
+{
+    "folders": [
+        {
+           "path": "XYZ"
+        }
+    ],
+    "settings": {
+        "rebase_default_base_ref": "develop"
+    }
+}
+```
 
 #### Rebase branch on top of other branch (`r`)
 


### PR DESCRIPTION
Some branching models (e.g. [gitflow](http://nvie.com/posts/a-successful-git-branching-model/)) use something other than `master` as an integration branch. In my case, I'm integrating against a branch called `dev` and only merging to `master` when I'm doing a stable release. This means that when I open the rebase dashboard I always need to switch base ref.

As the appropriate default base ref varies from repository to repository, I think a per-project setting in a project's `.sublime-project` file is the best place to override the default base ref. In the absence of this setting, or an active `.sublime-project`, I've retained the default behaviour of defaulting to `master`