### PR TITLE
Fix: super_key should be set to CTRL on Linux

### DIFF
--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -1,4 +1,4 @@
-import os
+import sys
 
 from .parse_diff import parse_diff
 from . import dates
@@ -9,4 +9,4 @@ from . import actions
 from . import debug
 from . import diff_string
 
-super_key = "SUPER" if os.name == "posix" else "CTRL"
+super_key = "SUPER" if sys.platform == "darwin" else "CTRL"


### PR DESCRIPTION
Since 983cf67 Linux key map has used `CTRL` instead of `SUPER`, but `common.util.super_key` was still set to `SUPER` on Linux as `os.name == 'posix'` is `true` on both Linux and OS X. Condition changed to `sys.platform == 'darwin'` which is only true on OS X.

Closes #190.