### PR TITLE
Feature: Display diffs against commit history from `git: log`

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -28,7 +28,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
     def run(self, **kwargs):
         sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
 
-    def run_async(self, in_cached_mode=False, file_path=None, current_file=False):
+    def run_async(self, in_cached_mode=False, file_path=None, current_file=False, base_commit=None):
         repo_path = self.repo_path
         if current_file:
             file_path = self.file_path or file_path
@@ -39,6 +39,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
         diff_view.settings().set("git_savvy.repo_path", repo_path)
         diff_view.settings().set("git_savvy.file_path", file_path)
         diff_view.settings().set("git_savvy.diff_view.in_cached_mode", in_cached_mode)
+        diff_view.settings().set("git_savvy.diff_view.base_commit", base_commit)
         self.window.focus_view(diff_view)
         diff_view.sel().clear()
         diff_view.run_command("gs_diff_refresh")
@@ -52,7 +53,10 @@ class GsDiffRefreshCommand(TextCommand, GitCommand):
 
     def run(self, edit, cursors=None):
         in_cached_mode = self.view.settings().get("git_savvy.diff_view.in_cached_mode")
-        stdout = self.git("diff", "--cached" if in_cached_mode else None, self.file_path)
+        base_commit = self.view.settings().get("git_savvy.diff_view.base_commit")
+
+        stdout = self.git(
+            "diff", base_commit,  "--cached" if in_cached_mode else None, "--", self.file_path)
 
         self.view.run_command("gs_replace_view_text", {"text": stdout})
 

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -49,11 +49,11 @@ class GsLogCommand(WindowCommand, GitCommand):
 
         self.window.show_quick_panel(
             self._entries,
-            self.on_selection,
+            self.on_hash_selection,
             flags=sublime.MONOSPACE_FONT
         )
 
-    def on_selection(self, index):
+    def on_hash_selection(self, index):
         if index == -1:
             return
         if index == self._limit:
@@ -61,8 +61,32 @@ class GsLogCommand(WindowCommand, GitCommand):
             sublime.set_timeout_async(lambda: self.run_async(), 1)
             return
 
-        selected_hash = self._hashes[index]
-        self.window.run_command("gs_show_commit", {"commit_hash": selected_hash})
+        self._selected_hash = self._hashes[index]
+
+        self.window.show_quick_panel(
+            [
+                "Show commit",
+                "Compare commit against working directory",
+                "Compare commit against index"
+            ],
+            self.on_output_selection,
+            flags=sublime.MONOSPACE_FONT
+        )
+
+    def on_output_selection(self, index):
+        if index == -1:
+            return
+
+        if index == 0:
+            self.window.run_command("gs_show_commit", {"commit_hash": self._selected_hash})
+
+        if index in [1, 2]:
+            self.window.run_command("gs_diff", {
+                "in_cached_mode": index == 2,
+                "file_path": self._filename,
+                "current_file": bool(self._filename),
+                "base_commit": self._selected_hash
+            })
 
 
 class GsLogCurrentFileCommand(WindowCommand, GitCommand):

--- a/docs/history.md
+++ b/docs/history.md
@@ -6,6 +6,11 @@ Opens a panel with a chronological list of all ancestors of the current commit. 
 
 By default, the list is paginated at 6,000 commits for performance reasons.  To view the next 6,000 commits, start typing `>>> NEXT`.  Whens selected, you will see a list with the next 6,000 commits.
 
+On selection of a commit you can choose from the following options:
+- `Show commit`: Display the commit.
+- `Compare commit against working directory`: Display the diff between the commit and the working directory.
+- `Compare commit against index`: Display the diff between the commit and staged changes in the index.
+
 ## `git: log current file`
 
 Performs a similar function to `git: log`, but restricts your search to the history of the currently open file.


### PR DESCRIPTION
![Preview](https://cloud.githubusercontent.com/assets/912471/7951494/e4b898ee-099f-11e5-9031-4bb1a51deca4.gif)

When the `show_log_output_options` setting is set to `true`, on selection of a commit from the `git: log` quick panel, a user can choose from the following options:

`Show commit`: Display the commit
`Show diff`: Display the diff between the commit and the working tree
`Show diff (cached)`: Display the diff between the commit and staged changes

Closes #172 