### PR TITLE
Fix: Git fetch with remotes=None should append --all option

### DIFF
--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -17,7 +17,7 @@ class RemotesMixin():
         If provided, fetch all changes from `remote`.  Otherwise, fetch
         changes from all remotes.
         """
-        self.git("fetch", "--prune" if prune else None, remote)
+        self.git("fetch", "--prune" if prune else None, remote if remote else "--all")
 
     def get_remote_branches(self):
         """


### PR DESCRIPTION
The fetch `All remotes.` option currently does not fetch all remotes (watch the upstream remote below):

![2015-06-10 13_31_53](https://cloud.githubusercontent.com/assets/912471/8082411/11f803d2-0f75-11e5-8dba-8b8544fd3b00.gif)

The GitSavvy `RemotesMixin.fetch` function expects git to fetch all remotes if a remote isn't specified, but according to the git docs it will default to `origin`:

```
When no remote is specified, by default the origin remote will be used,
unless there’s an upstream branch configured for the current branch.
```
http://git-scm.com/docs/git-fetch/2.4.0

To fix I've appended the `--all` option if remote is falsey.
