### PR TITLE
Feature: git reset, using log or reflog

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -207,5 +207,13 @@
     {
         "caption": "git: rebase",
         "command": "gs_show_rebase"
+    },
+    {
+        "caption": "git: reset",
+        "command": "gs_reset"
+    },
+    {
+        "caption": "git: reset (reflog)",
+        "command": "gs_reset_reflog"
     }
 ]

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -17,3 +17,4 @@ from .merge import*
 from .changelog import *
 from .status_bar import *
 from .tags import *
+from .reset import *

--- a/core/commands/reset.py
+++ b/core/commands/reset.py
@@ -1,0 +1,59 @@
+import sublime
+
+from .log import GsLogCommand
+from ...common import util
+
+
+class GsResetCommand(GsLogCommand):
+
+    def on_hash_selection(self, index):
+        if index == -1:
+            return
+        if index == self._limit:
+            self._pagination += self._limit
+            sublime.set_timeout_async(lambda: self.run_async(), 1)
+            return
+
+        self.git("reset", "--mixed", self._hashes[index])
+
+
+class GsResetReflogCommand(GsResetCommand):
+
+    def run_async(self):
+        log_output = self.git(
+            "reflog",
+            "-{}".format(self._limit) if self._limit else None,
+            "--skip={}".format(self._pagination) if self._pagination else None,
+            '--format=%h%n%H%n%s%n%gs%n%gd%n%an%n%at%x00'
+        ).strip("\x00")
+
+        self._entries = []
+        self._hashes = []
+        for entry in log_output.split("\x00"):
+            try:
+                short_hash, long_hash, summary, reflog_name, reflog_selector, author, datetime = (
+                    entry.strip("\n").split("\n"))
+
+                self._entries.append([
+                    reflog_selector + " " + reflog_name,
+                    short_hash + " " + summary,
+                    author + ", " + util.dates.fuzzy(datetime)
+                ])
+                self._hashes.append(long_hash)
+
+            except ValueError:
+                # Empty line - less expensive to catch the exception once than
+                # to check truthiness of entry.strip() each time.
+                pass
+
+        if not len(self._entries) < self._limit:
+            self._entries.append([
+                ">>> NEXT {} COMMITS >>>".format(self._limit),
+                "Skip this set of reflog entries and choose from the next-oldest batch."
+            ])
+
+        self.window.show_quick_panel(
+            self._entries,
+            self.on_hash_selection,
+            flags=sublime.MONOSPACE_FONT
+        )

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -7,3 +7,13 @@ This command will initialize a new repository, or re-initialize a pre-existing o
 When run, you will asked to confirm the root directory of the new Git repository.  GitSavvy will attempt to auto-detect this for you.
 
 This command will also be suggested to you should you attempt to run a GitSavvy command on a file that is not within a valid Git repository.
+
+## `git: reset`
+
+This command will change the HEAD of the current branch to a previous commit.
+
+When run, you will be asked to select a commit from a list of previous commits. Once you select a commit, the HEAD of the current branch will be changed to the selected commit, and any changes that were committed after the selected commit will appear as unstaged changes in the working directory.
+
+## `git: reset (reflog)`
+
+Like `git: reset`, this command will change the HEAD of the current branch to a previous commit, but uses `git reflog` rather than `git log` as the source of available commits.


### PR DESCRIPTION
![2015-06-11 22_40_30](https://cloud.githubusercontent.com/assets/912471/8119107/04be56fa-108b-11e5-8c05-309c66131eaa.gif)

I've made a first attempt at a git reset feature (closes #200). Feedback welcomed :smile: 

Adds two git reset commands to the command panel:
- `git: reset`: Displays the commit selector from `git: log`, selecting a commit performs a `git reset --mixed` to that commit.
- `git: reset (reflog)` Displays a reference log selector, selecting a reference performs a `git reset --mixed` to the referenced commit. This allows you to reset an earlier reset or a rebase.

Reflog quick panel:
![screen shot 2015-06-11 at 23 43 51](https://cloud.githubusercontent.com/assets/912471/8120160/03bffef8-1094-11e5-822d-3abc02f201b8.png)


The reflog option could be confusing to less advanced git users. I personally would find it useful, on occasion I've reset one or two commits too far, and it would be nice if I could quickly undo that without returning to the terminal. If it's more trouble than it's worth though, I'm happy to take it out.

Doc entries are pretty rough (particularly for the `reflog` option), so welcome feedback there. Wasn't sure whether to put them in `misc.md` or elsewhere.

I'm using the default git reset behaviour `--mixed` (though I've added it to command anyway just to be explicit). I didn't add an option for `--soft` or `--hard` to keep things simple, from the status view it's easy to either stage or discard the post-reset uncommited changes anyway.

@divmain In `GsResetCommand` I subclassed `GsLogCommand` as the only difference between the two is the `on_hash_selection` method, but it might be better not to subclass and live with the duplication, as the subclassing is less explicit and future changes to `GsLogCommand` could potentially break `GsResetCommand`. What do you think?
