### PR TITLE
Fix: Stash shortcuts do not execute when cursor is at end of line

### DIFF
--- a/syntax/status.YAML-tmLanguage
+++ b/syntax/status.YAML-tmLanguage
@@ -45,7 +45,7 @@ patterns:
   end: '^$'
   patterns:
   - name: meta.git-savvy.status.saved_stash
-    match: '^    (.+)$'
+    match: '^    (.+)\n$'
 
 - comment: Key-bindings menu
   name: comment.git-savvy.status.key-bindings-menu

--- a/syntax/status.tmLanguage
+++ b/syntax/status.tmLanguage
@@ -117,7 +117,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>^    (.+)$</string>
+					<string>^    (.+)\n$</string>
 					<key>name</key>
 					<string>meta.git-savvy.status.saved_stash</string>
 				</dict>


### PR DESCRIPTION
Matching regex for meta.git-savvy.status.saved_stash did not include end of line.

Closes #196.