### PR TITLE
Fix: rebase dashboard shortcuts

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -596,7 +596,7 @@
         "command": "gs_rebase_open_file",
         "context": [
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "keyword.other.name.git-savvy.rebase-conflict" }
+            { "key": "selector", "operator": "equal", "operand": "meta.git-savvy.rebase-graph.conflict" }
         ]
     },
     {
@@ -604,7 +604,7 @@
         "command": "gs_rebase_stage_file",
         "context": [
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "keyword.other.name.git-savvy.rebase-conflict" }
+            { "key": "selector", "operator": "equal", "operand": "meta.git-savvy.rebase-graph.conflict" }
         ]
     },
     {
@@ -612,7 +612,7 @@
         "command": "gs_rebase_use_commit_version",
         "context": [
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "keyword.other.name.git-savvy.rebase-conflict" }
+            { "key": "selector", "operator": "equal", "operand": "meta.git-savvy.rebase-graph.conflict" }
         ]
     },
     {
@@ -620,7 +620,7 @@
         "command": "gs_rebase_use_base_version",
         "context": [
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "keyword.other.name.git-savvy.rebase-conflict" }
+            { "key": "selector", "operator": "equal", "operand": "meta.git-savvy.rebase-graph.conflict" }
         ]
     },
     {
@@ -628,7 +628,7 @@
         "command": "gs_rebase_launch_merge_tool",
         "context": [
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "keyword.other.name.git-savvy.rebase-conflict" }
+            { "key": "selector", "operator": "equal", "operand": "meta.git-savvy.rebase-graph.conflict" }
         ]
     },
     {

--- a/syntax/rebase.YAML-tmLanguage
+++ b/syntax/rebase.YAML-tmLanguage
@@ -17,7 +17,7 @@ patterns:
     match: '^  STATUS:.+'
 
 - name: meta.git-savvy.rebase-graph.conflict
-  match: '^(    ┃           )(.+)'
+  match: '^(    ┃           )(.+)\n'
   captures:
     '1':
       name: comment.git-savvy.rebase-graph.separator

--- a/syntax/rebase.tmLanguage
+++ b/syntax/rebase.tmLanguage
@@ -52,7 +52,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(    ┃           )(.+)</string>
+			<string>^(    ┃           )(.+)\n</string>
 			<key>name</key>
 			<string>meta.git-savvy.rebase-graph.conflict</string>
 		</dict>


### PR DESCRIPTION
@divmain I've checked the other key binding contexts as we discussed in #202

| Key binding context                                           | Syntax file                | Pattern captures line endings |
|---------------------------------------------------------------|----------------------------|-----------------------------------------|
| meta.git-savvy.status.file                                   | status.tmLanguage  | Yes
| meta.git-savvy.tags.tag                                     | tags.tmLanguage     | Yes
| meta.git-savvy.status.saved_stash                   | status.tmLanguage  | Yes
| meta.git-savvy.rebase-graph.entry                   | rebase.tmLanguage | Yes
| keyword.other.name.git-savvy.rebase-conflict | rebase.tmLanguage | No
| meta.link.inline.markdown                                | From ST3                 | n/a

One additional fix came out of that check, on the rebase dashboard, when there's a conflict the cursor must be within a conflicting file name to trigger shortcuts like `[o] open file`. I've changed the context from `keyword.other.name.git-savvy.rebase-conflict` to `meta.git-savvy.rebase-graph.conflict` as this allows shortcuts to be triggered from anywhere on the same line as the conflicting file. I also added `\n` to meta.git-savvy.rebase-graph.conflict so that the pattern matches the end of the line.