### PR TITLE
Prompt before discarding commit message

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -134,5 +134,10 @@
         NOTE: Changes you make may break in-view functionality, so use with caution.
      */
     // "git_graph_args": ["log", "--pretty=format:%h%d (%ar) by `%an` %s", "--graph"],
-    "git_graph_args": ["log", "--oneline", "--graph", "--decorate"]
+    "git_graph_args": ["log", "--oneline", "--graph", "--decorate"],
+
+    /*
+        Set to False to abort commit and drop message without a prompt
+    */
+    "prompt_on_abort_commit": false
 }

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -55,7 +55,8 @@ class GsCommitCommand(WindowCommand, GitCommand):
 
         title = COMMIT_TITLE.format(os.path.basename(repo_path))
         view.set_name(title)
-        view.set_scratch(True)
+        if not gitsavvy_settings.get("prompt_on_abort_commit"):
+            view.set_scratch(True)
         view.run_command("gs_commit_initialize_view")
 
 
@@ -127,6 +128,7 @@ class GsCommitViewDoCommitCommand(TextCommand, GitCommand):
             )
 
         self.view.window().focus_view(self.view)
+        self.view.set_scratch(True)  # ignore dirty on actual commit
         self.view.window().run_command("close_file")
 
 


### PR DESCRIPTION
### Changes

* display prompt by default
* allow toggling behavior with "prompt_on_abort_commit" setting
* always set to scratch on commit (no need to prompt)

### Reasoning

Coming in from writing commit message with command line editors,
quitting the view mid-commit is always considered dirty in my mind.

And so I often found myself closing a commit by habit and losing
changes without recover options. 

I've considered different solutions for this problem but could not
find anything as simple that worked for me until now.

The same behavior is also used in by the popular plugin "sublime git"
which is where some users come from (including myself).

### WIP

This is a simple change, however if anyone wants to change anything
about this behavior or make it disabled by default, please let me know
and I'll amend the PR.