### PR TITLE
Bug: Branch matching regex did not match dots in remote branch name

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -30,7 +30,7 @@ class BranchesMixin():
         if not line:
             return None
 
-        pattern = r"(\* )?(remotes/)?([a-zA-Z0-9\-\_\/\.]+(?<!\.lock)(?<!\/)(?<!\.)\b) +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\\]+)(: ([^\]]+))?\] )?(.*)"
+        pattern = r"(\* )?(remotes/)?([a-zA-Z0-9\-\_\/\.]+(?<!\.lock)(?<!\/)(?<!\.)\b) +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\.]+)(: ([^\]]+))?\] )?(.*)"
         r"((: ))?"
 
         match = re.match(pattern, line)


### PR DESCRIPTION
Fixed branch matching regex so it matches remote branch names containing dots.

**Before:**
<img width="598" alt="screen shot 2015-07-25 at 21 06 49" src="https://cloud.githubusercontent.com/assets/912471/8891145/1c6d0a4c-3315-11e5-9c8d-8705e28fd2d3.png">

**After:**
<img width="595" alt="screen shot 2015-07-25 at 21 26 01" src="https://cloud.githubusercontent.com/assets/912471/8891144/023cb910-3315-11e5-9405-e2c7c39fe45f.png">