### PR TITLE
Enhancement: Add setting to hide git-flow commands

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -140,5 +140,10 @@
         When set to `true`, GitSavvy will prompt for confirmation when closing
         the commit message view.
     */
-    "prompt_on_abort_commit": false
+    "prompt_on_abort_commit": false,
+
+    /*
+        When set to `true`, GitSavvy will display git-flow integration commands
+    */
+    "show_git_flow_commands": true
 }

--- a/core/commands/flow.py
+++ b/core/commands/flow.py
@@ -33,6 +33,10 @@ class FlowCommon(WindowCommand, GitCommand):
         if not self.flow_settings['branch.master']:
             self.window.show_quick_panel([INIT_REQUIRED_MSG], None)
 
+    def is_visible(self, **kwargs):
+        gitsavvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        return gitsavvy_settings.get("show_git_flow_commands")
+
     def _generic_select(self, help_text, options, callback,
                         no_opts="There are no branches available"):
         """

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -27,3 +27,7 @@ When running this command you will be prompted to provide a feature name. The co
 ## `flow: feature pull`
 
 This will pull a feature from a given remote (not necessarily the configured default remote) and check it out. You will be first prompted to select a remote and then to provide a feature name.
+
+## Hiding git-flow commands
+
+If you do not use git-flow, you can hide these commands by setting `show_git_flow_commands` to `false` in `Packages/User/GitSavvy.sublime-settings`.


### PR DESCRIPTION
Git-flow commands are only functional if the [git-flow Git extenstions](https://github.com/nvie/gitflow) are installed. Added a setting to hide `flow: *` commands for users who don't use git-flow.