### PR TITLE
Allowing git_path to be customized on a per-platform basis.

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -7,9 +7,23 @@
 
     /*
         Uncomment the setting below to explicitly set which git binary
-        to use.
+        to use.  An empty string will search PATH for "git".  The setting may
+        be a direct string to a git binary, e.g.:
+
+            "git_path": "/usr/bin/git",
+
+        Or it may be a dictionary keyed off what sublime.platform() returns,
+        so it may be customized on a per-platform basis.  e.g.:
+
+            "git_path": {
+                "default": "",
+                "windows": "C:/Program Files/Git/cmd/git.exe"
+            },
      */
-    // "git_path": "/usr/bin/git",
+    "git_path": {
+        "default": "",
+        "windows": "C:/Program Files/Git/cmd/git.exe"
+    },
 
     /*
         Change this to `true` when doing dev work on GitSavvy.

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -137,10 +137,17 @@ class GitCommand(StatusMixin,
         """
 
         global git_path
-        git_path = (git_path or
-                    sublime.load_settings("GitSavvy.sublime-settings").get("git_path") or
-                    shutil.which("git")
-                    )
+        if not git_path:
+            git_path_setting = sublime.load_settings("GitSavvy.sublime-settings").get("git_path")
+            if isinstance(git_path_setting, dict):
+                git_path = git_path_setting.get(sublime.platform())
+                if not git_path:
+                    git_path = git_path_setting.get('default')
+            else:
+                git_path = git_path_setting
+
+            if not git_path:
+                git_path = shutil.which("git")
 
         if not git_path:
             msg = ("Your Git binary cannot be found.  If it is installed, add it "


### PR DESCRIPTION
On Windows, git isn't always in PATH, requiring you to set git_path for GitSavvy to work correctly.  For users that sync settings across platforms, this allows git_path to be (optionally) customized on a per-platform basis.