### PR TITLE
Enhancement: Additional git blame display options

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -25,6 +25,24 @@ A GitHub-style blame view is displayed.  Each hunk of the file will be shown on 
 
 Pressing `SUPER-Enter` (`CTRL-Enter` in Windows) while your cursor is inside a hunk will take you to that specific commit.
 
+### Blame options
+When run, you will be prompted for how you want the blame view to search for changes:
+
+#### Default
+Use default `git blame` behaviour.
+
+#### Ignore whitespace
+Ignore whitespace only changes when finding the last commit that changed the line (`git blame -w`).
+
+#### Detect moved or copied lines within same file
+Ignore whitespace, and detect when lines have been moved or copied within the file, attributing lines to the original commit rather than the commit that moved or copied them (`git blame -w -M`).
+
+#### Detect moved or copied lines within same commit
+Ignore whitespace, and detect when lines have been moved or copied from any file modified in the same commit, attributing lines to the original commit rather than the commit that moved or copied them (`git blame -w -C`).
+
+#### Detect moved or copied lines across all commits
+Ignore whitespace, and detect when lines have been moved or copied from any file across the full commit history of the repository, attributing lines to the original commit rather than the commit that moved or copied them (`git blame -w -CCC`).
+
 ## `git: graph current branch`
 
 Opens a special view that displays an ASCII-graphic representation of the repo's commit and branch history.


### PR DESCRIPTION
![2015-08-14 17_20_52](https://cloud.githubusercontent.com/assets/912471/9278588/aeb0a03c-42a9-11e5-8602-739edbbfb738.gif)

This adds additional options to the git blame view. I occasionally "blame" the wrong person for a change, because they fixed indentation, moved a function within a file, or broke a large file up into smaller files. When using git blame from the command line I can use the `-w`, `-M` and `-C` flags to find the last real change to a line. This adds similar functionality to GitSavvy.