### PR TITLE
Bug: properly iterate over an enumerated argument list

### DIFF
--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -26,7 +26,7 @@ class GsCustomCommand(WindowCommand, GitCommand):
         if not args:
             sublime.error_message("Custom command must provide args.")
 
-        for idx, arg in args:
+        for idx, arg in enumerate(args):
             if arg == "{REPO_PATH}":
                 args[idx] = self.repo_path
             elif arg == "{FILE_PATH}":


### PR DESCRIPTION
Without this fix, running a custom command raises the following exception:

    Traceback (most recent call last):
      File ".../Sublime Text 3/Packages/GitSavvy/core/commands/custom.py", line 18, in <lambda>
        sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
      File ".../Sublime Text 3/Packages/GitSavvy/core/commands/custom.py", line 29, in run_async
        for idx, arg in args:
    ValueError: too many values to unpack (expected 2)