### PR TITLE
Feature: simple background thread for custom commands

### DIFF
--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -1,4 +1,5 @@
 import sublime
+import threading
 from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
@@ -6,6 +7,17 @@ from ...common import util
 
 
 ALL_REMOTES = "All remotes."
+
+
+class CustomCommandThread(threading.Thread):
+    def __init__(self, func, *args, **kwargs):
+        super(CustomCommandThread, self).__init__(**kwargs)
+        self.cmd_args = args
+        self.cmd_func = func
+        self.daemon = True
+
+    def run(self):
+        return self.cmd_func(*self.cmd_args)
 
 
 class GsCustomCommand(WindowCommand, GitCommand):
@@ -21,7 +33,8 @@ class GsCustomCommand(WindowCommand, GitCommand):
                   output_to_panel=False,
                   args=None,
                   start_msg="Starting custom command...",
-                  complete_msg="Completed custom command."):
+                  complete_msg="Completed custom command.",
+                  run_in_thread=False):
 
         if not args:
             sublime.error_message("Custom command must provide args.")
@@ -33,7 +46,12 @@ class GsCustomCommand(WindowCommand, GitCommand):
                 args[idx] = self.file_path
 
         sublime.status_message(start_msg)
-        stdout = self.git(*args)
+        if run_in_thread:
+            stdout = ''
+            cmd_thread = CustomCommandThread(self.git, *args)
+            cmd_thread.start()
+        else:
+            stdout = self.git(*args)
         sublime.status_message(complete_msg)
 
         if output_to_panel:


### PR DESCRIPTION
There's no documentation, I just wanted to pitch the idea first.

The custom commands work well for short duration commands; however, for long running commands the
plugin is blocked in the `subprocess` `communicate()` call (polling for stdout/err).