### PR TITLE
Feature: Open file to change when in inline diff

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -54,6 +54,12 @@
         "context": [
             { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
         ]
+    },    {
+        "keys": ["o"],
+        "command": "gs_inline_diff_open_file",
+        "context": [
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+        ]
     },
 
     /////////////////////////////////

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -6,6 +6,8 @@ Running this command will open a special "Inline Diff" view related to the open 
 
 While in this view, you can navigate between changed hunks using the `,` and `.` keys.  `,` will take you to the previous hunk and `.` will take you to the next hunk. If you have the `inline_diff_auto_scoll` setting set to `true`, the cursor will be automatically placed on the first hunk when the view is opened.
 
+To open the file to make a change(s) to it, use `o`. It will open it on the exact line and letter(called column).
+
 While the cursor is positioned at a hunk, you can stage that hunk by pressing `h`.  If you'd like to stage a line only, and _not_ the full hunk, move the cursor to the desired line and press `l` (lower-case L).
 
 You also have the option of resetting hunks.  To do so, press `H` (shift-H).  This will cause changes made in that hunk to be removed from the file in the working directory.  You can also reverse individual lines by positioning the cursor and pressing `L`.  Keep in mind that these actions **are** destructive.


### PR DESCRIPTION
I created the feature to open file you that is open in inline diff.
Currently it is only for while you are in a hunk, but it should be implemented to do this for outside as well. 
If you have a good idea how to make this easily, I would like to hear it ✨ 

closes divmain/GitSavvy#236