### PR TITLE
Fix: branch names ending on -

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -58,7 +58,7 @@ class GsCheckoutNewBranchCommand(WindowCommand, GitCommand):
         self.window.show_input_panel(NEW_BRANCH_PROMPT, name, self.on_done, None, None)
 
     def on_done(self, branch_name):
-        pattern = r"^(?!\.|.*\.\..*|.*@.*|\/)[a-zA-Z0-9\-\_\/\.]+(?<!\.lock)(?<!\/)(?<!\.)\b$"
+        pattern = r"^(?!\.|.*\.\..*|.*@.*|\/)[a-zA-Z0-9\-\_\/\.]+(?<!\.lock)(?<!\/)(?<!\.)$"
         match = re.match(pattern, branch_name)
         if not match:
             sublime.error_message("`{}` is a invalid branch name.\nRead more on $(man git-check-ref-format)".format(branch_name))

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -30,7 +30,7 @@ class BranchesMixin():
         if not line:
             return None
 
-        pattern = r"(\* )?(remotes/)?([a-zA-Z0-9\-\_\/\.]+(?<!\.lock)(?<!\/)(?<!\.)\b) +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\.]+)(: ([^\]]+))?\] )?(.*)"
+        pattern = r"(\* )?(remotes/)?([a-zA-Z0-9\-\_\/\.\-]+(?<!\.lock)(?<!\/)(?<!\.)) +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\.]+)(: ([^\]]+))?\] )?(.*)"
         r"((: ))?"
 
         match = re.match(pattern, line)


### PR DESCRIPTION
closes divmain/GitSavvy#251


simply just remove the \b. (if you don't remember like me) \b mean that is should be end of a string and have a *blank* character after. Therefor it did not match `some-name-`. It exist \B that is  the opposite of \b. So it it matches with a symbol like -+!~@#$% etc..

I did not see why it was needed. I guess there were some reason it got added there, so. Do any of you remember why?