### PR TITLE
Improve: Git Graph has refresh function

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -548,6 +548,13 @@
         ]
     },
     {
+        "keys": ["r"],
+        "command": "gs_log_graph_refresh",
+        "context": [
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_log_graph_next_commit",
         "args": {"forward": true},

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -21,9 +21,21 @@ class GsLogGraphCommand(WindowCommand, GitCommand):
         view.settings().set("git_savvy.log_graph_view", True)
         view.settings().set("git_savvy.repo_path", repo_path)
         view.settings().set("word_wrap", False)
+        view.settings().set("all_branches", all_branches)
         view.set_name(LOG_GRAPH_TITLE)
         view.set_scratch(True)
         view.set_read_only(True)
+        view.run_command("gs_log_graph_initialize", {"all_branches": all_branches})
+
+class GsLogGraphRefreshCommand(WindowCommand, GitCommand):
+
+    """
+    Refresh the current graph view with the latest commits.
+    """
+
+    def run(self):
+        view = self.window.active_view()
+        all_branches = view.settings().get("all_branches")
         view.run_command("gs_log_graph_initialize", {"all_branches": all_branches})
 
 


### PR DESCRIPTION
Did not nuke the position since you are refreshing to see the new commits
and the new commits will be on top of the graph

closes #259 