### PR TITLE
Fix: Syntax for graph

### DIFF
--- a/syntax/graph.YAML-tmLanguage
+++ b/syntax/graph.YAML-tmLanguage
@@ -17,7 +17,9 @@ patterns:
   match: (`.*`)
 - comment: branch names
   name: constant.other.git-savvy.graph.branch-name
-  match: (?<= )(\(.*\))(?= )
+  # match all sting starting on '(' and end on ')'
+  # and not contain any '(' or ')' in the string
+  match: (?<= )(\([^()]*\))(?= )
 - comment: issue numbers
   name: string.other.git-savvy.graph.issue
   match: (?:[Ff]ix(?:e[ds])?|[Rr]esolve[ds]?|[Cc]lose[ds]?)?\s*(?:#\d+|\[.*?\])

--- a/syntax/graph.tmLanguage
+++ b/syntax/graph.tmLanguage
@@ -38,7 +38,7 @@
 			<key>comment</key>
 			<string>branch names</string>
 			<key>match</key>
-			<string>(?&lt;= )(\(.*\))(?= )</string>
+			<string>(?&lt;= )(\([^()]*\))(?= )</string>
 			<key>name</key>
 			<string>constant.other.git-savvy.graph.branch-name</string>
 		</dict>


### PR DESCRIPTION
I change regex from `(.*)` to `([^()]*)` since than it only match what is should match
Now reqex expect '(' than character other than '()' ')'
```
xxxxxx2 (master)(2 hours ago) by `Simon` Type: change(removes type) to => two
new     ^^^^^^^^^^^^^^^^^^^^^
old     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

xxxxxx1 (1 hours ago) by `Simon` My  message is awsome :)
new     ^^^^^^^^^^^^^
old     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```