### PR TITLE
Enhancement: shift-tab to cycle dashboards in reverse

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -315,6 +315,14 @@
             { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["shift+tab"],
+        "command": "gs_tab_cycle",
+        "args": { "source": "status", "reverse": true },
+        "context": [
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
 
     /////////////////
     // COMMIT VIEW //
@@ -456,6 +464,14 @@
             { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["shift+tab"],
+        "command": "gs_tab_cycle",
+        "args": { "source": "tags", "reverse": true },
+        "context": [
+            { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
+        ]
+    },
 
     ///////////////////
     // BRANCHES VIEW //
@@ -589,6 +605,14 @@
             { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
         ]
     },
+    {
+        "keys": ["shift+tab"],
+        "command": "gs_tab_cycle",
+        "args": { "source": "branch", "reverse": true },
+        "context": [
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
 
     ////////////////
     // GRAPH VIEW //
@@ -636,6 +660,14 @@
         "keys": ["tab"],
         "command": "gs_tab_cycle",
         "args": { "source": "graph" },
+        "context": [
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["shift+tab"],
+        "command": "gs_tab_cycle",
+        "args": { "source": "graph", "reverse": true },
         "context": [
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
         ]
@@ -778,6 +810,14 @@
         "keys": ["tab"],
         "command": "gs_tab_cycle",
         "args": { "source": "rebase" },
+        "context": [
+            { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["shift+tab"],
+        "command": "gs_tab_cycle",
+        "args": { "source": "rebase", "reverse": true },
         "context": [
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true }
         ]

--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -24,8 +24,8 @@ class GsTabCycleCommand(TextCommand, GitCommand):
         "graph": "git_savvy.log_graph_view"
     }
 
-    def run(self, edit, source=None, target=None):
-        to_load = target or self.get_next(source)
+    def run(self, edit, source=None, target=None, reverse=False):
+        to_load = target or self.get_next(source, reverse)
         view_signature = self.view_signatures[to_load]
 
         self.view.window().run_command("hide_panel", {"cancel": True})
@@ -34,9 +34,12 @@ class GsTabCycleCommand(TextCommand, GitCommand):
         if not self.view.settings().get(view_signature):
             self.view.close()
 
-    def get_next(self, source):
+    def get_next(self, source, reverse=False):
         savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         tab_order = savvy_settings.get("tab_order")
+
+        if reverse == True:
+            tab_order.reverse()
 
         source_idx = tab_order.index(source)
         next_idx = 0 if source_idx == len(tab_order) - 1 else source_idx + 1

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -55,9 +55,10 @@ class BranchInterface(ui.Interface, GitCommand):
       [H] diff history against active
       [E] edit branch description
 
-      [e] toggle display of remote branches
-      [tab] transition to next dashboard
-      [r]   refresh
+      [e]         toggle display of remote branches
+      [tab]       transition to next dashboard
+      [SHIFT-tab] transition to previous dashboard
+      [r]         refresh
 
     -
     """

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -58,7 +58,8 @@ class RebaseInterface(ui.Interface, GitCommand):
       [u] move commit up (before previous)      [A] abort rebase
       [w] show commit
 
-      [tab] transition to next dashboard
+      [tab]       transition to next dashboard
+      [SHIFT-tab] transition to previous dashboard
 
       [{super_key}-Z] undo previous action
       [{super_key}-Y] redo action

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -66,16 +66,17 @@ class StatusInterface(ui.Interface, GitCommand):
       [P] push current branch               [t][c] create stash
                                             [t][u] create stash including untracked files
       [i] ignore file                       [t][d] discard stash
-      [I] ignore pattern                    
+      [I] ignore pattern
 
       ###########
       ## OTHER ##
       ###########
 
-      [r]   refresh status
-      [tab] transition to next dashboard
-      [.]   move cursor to next file
-      [,]   move cursor to previous file
+      [r]         refresh status
+      [tab]       transition to next dashboard
+      [SHIFT-tab] transition to previous dashboard
+      [.]         move cursor to next file
+      [,]         move cursor to previous file
 
     -
     """

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -58,10 +58,10 @@ class TagsInterface(ui.Interface, GitCommand):
       ## ACTIONS ##                   ## OTHER ##
       #############                   ###########
 
-      [c] create                      [r]   refresh dashboard
-      [d] delete                      [e]   toggle display of remote branches
-      [p] push to remote              [tab] transition to next dashboard
-      [P] push all tags to remote
+      [c] create                      [r]         refresh dashboard
+      [d] delete                      [e]         toggle display of remote branches
+      [p] push to remote              [tab]       transition to next dashboard
+      [P] push all tags to remote     [SHIFT-tab] transition to previous dashboard
       [l] view commit
 
     -

--- a/syntax/branch.YAML-tmLanguage
+++ b/syntax/branch.YAML-tmLanguage
@@ -14,7 +14,7 @@ patterns:
   patterns:
   - comment: root summary
     name: comment.git-savvy.status.root-summary
-    match: '^  ROOT:.+' 
+    match: '^  ROOT:.+'
   - comment: branch names
     name: constant.other.git-savvy.status.branch-name
     match: '`[^`]+`'
@@ -57,6 +57,6 @@ patterns:
     captures:
       '1': { name: support.type.git-savvy.key-bindings-header-text }
   - name: meta.git-savvy.key-bindings-key-stroke
-    match: '\[([A-Za-z]+)\]'
+    match: '\[([A-Za-z\-]+)\]'
     captures:
       '1': { name: constant.character.git-savvy-key-binding-key }

--- a/syntax/branch.tmLanguage
+++ b/syntax/branch.tmLanguage
@@ -103,6 +103,14 @@
 					<string>meta.git-savvy.branches.branch</string>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>comment.git-savvy.branches.branch.extra-info</string>
+						</dict>
+					</dict>
 					<key>match</key>
 					<string>^  ▸ [0-9a-f]{7} [^ ]+( .*)\n$</string>
 					<key>name</key>
@@ -153,7 +161,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\[([A-Za-z]+)\]</string>
+					<string>\[([A-Za-z\-]+)\]</string>
 					<key>name</key>
 					<string>meta.git-savvy.key-bindings-key-stroke</string>
 				</dict>

--- a/syntax/status.YAML-tmLanguage
+++ b/syntax/status.YAML-tmLanguage
@@ -14,7 +14,7 @@ patterns:
   patterns:
   - comment: root summary
     name: comment.git-savvy.status.root-summary
-    match: '^  ROOT:.+' 
+    match: '^  ROOT:.+'
   - comment: branch names
     name: constant.other.git-savvy.status.branch-name
     match: '`[^`]+`'
@@ -57,6 +57,6 @@ patterns:
     captures:
       '1': { name: support.type.git-savvy.key-bindings-header-text }
   - name: meta.git-savvy.key-bindings-key-stroke
-    match: '\[([A-Za-z\,\.]+)\]'
+    match: '\[([A-Za-z\,\.\-]+)\]'
     captures:
       '1': { name: constant.character.git-savvy-key-binding-key }

--- a/syntax/status.tmLanguage
+++ b/syntax/status.tmLanguage
@@ -158,7 +158,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\[([A-Za-z\,\.]+)\]</string>
+					<string>\[([A-Za-z\,\.\-]+)\]</string>
 					<key>name</key>
 					<string>meta.git-savvy.key-bindings-key-stroke</string>
 				</dict>

--- a/syntax/tags.YAML-tmLanguage
+++ b/syntax/tags.YAML-tmLanguage
@@ -66,6 +66,6 @@ patterns:
     captures:
       '1': { name: support.type.git-savvy.key-bindings-header-text }
   - name: meta.git-savvy.key-bindings-key-stroke
-    match: '\[([A-Za-z]+)\]'
+    match: '\[([A-Za-z\-]+)\]'
     captures:
       '1': { name: constant.character.git-savvy-key-binding-key }

--- a/syntax/tags.tmLanguage
+++ b/syntax/tags.tmLanguage
@@ -187,7 +187,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\[([A-Za-z]+)\]</string>
+					<string>\[([A-Za-z\-]+)\]</string>
 					<key>name</key>
 					<string>meta.git-savvy.key-bindings-key-stroke</string>
 				</dict>


### PR DESCRIPTION
Tab cycling through dashboards is an awesome thing, but there was no way to go back to the previous one and in the discussion in #261 it was mentioned briefly as an issue but wasn't really resolved as the discussion there went in a different direction.

Why not just remove the unnecessary dashboards through the config? Unless you remove everything but two dashboards, this still is a nice enhancement to have.

This adds the keybinding (as is common, if I cycle one way with tab then shift-tab should cycle it back) and lists it in the various dashboards (with proper syntax coloring).

I've used [SHIFT-tab] in the dashboard keybinding lists, to be in line with [SUPER-Z] keybindings in the rebase dashboard. 