### PR TITLE
Better commit on close behavior

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -8,7 +8,8 @@
         "keys": ["ctrl+enter"],
         "command": "gs_commit_view_do_commit",
         "context": [
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_on_close", "operator": "equal", "operand": false }
         ]
     },
     {

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -8,7 +8,8 @@
         "keys": ["super+enter"],
         "command": "gs_commit_view_do_commit",
         "context": [
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_on_close", "operator": "equal", "operand": false }
         ]
     },
     {

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -8,7 +8,8 @@
         "keys": ["ctrl+enter"],
         "command": "gs_commit_view_do_commit",
         "context": [
-            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.commit_on_close", "operator": "equal", "operand": false }
         ]
     },
     {

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -125,13 +125,15 @@ class GsCommitViewDoCommitCommand(TextCommand, GitCommand):
     make a commit using the text for the commit message.
     """
 
-    def run(self, edit):
-        sublime.set_timeout_async(self.run_async, 0)
+    def run(self, edit, message=None):
+        sublime.set_timeout_async(lambda: self.run_async(commit_message=message), 0)
 
-    def run_async(self):
-        view_text = self.view.substr(sublime.Region(0, self.view.size()))
-        help_text = self.view.settings().get("git_savvy.commit_view.help_text")
-        commit_message = view_text.split(help_text)[0]
+    def run_async(self, commit_message=None):
+        if commit_message is None:
+            view_text = self.view.substr(sublime.Region(0, self.view.size()))
+            help_text = self.view.settings().get("git_savvy.commit_view.help_text")
+            commit_message = view_text.split(help_text)[0]
+
         include_unstaged = self.view.settings().get("git_savvy.commit_view.include_unstaged")
 
         show_panel_overrides = \
@@ -193,4 +195,4 @@ class GsCommitViewCloseCommand(TextCommand, GitCommand):
             message_txt = message_txt.strip()
 
             if message_txt:
-                self.view.run_command("gs_commit_view_do_commit")
+                self.view.run_command("gs_commit_view_do_commit", {"message": message_txt})

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -149,9 +149,12 @@ class GsCommitViewDoCommitCommand(TextCommand, GitCommand):
             stdin=commit_message
             )
 
-        self.view.window().focus_view(self.view)
-        self.view.set_scratch(True)  # ignore dirty on actual commit
-        self.view.window().run_command("close_file")
+        # ensure view is not already closed (i.e.: when "commit_on_close" enabled)
+        is_commit_view = self.view.settings().get("git_savvy.commit_view")
+        if is_commit_view and self.view.window():
+            self.view.window().focus_view(self.view)
+            self.view.set_scratch(True)  # ignore dirty on actual commit
+            self.view.window().run_command("close_file")
 
 
 class GsCommitViewSignCommand(TextCommand, GitCommand):

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -64,9 +64,10 @@ class GsCommitCommand(WindowCommand, GitCommand):
         else:
             view.set_syntax_file("Packages/GitSavvy/syntax/make_commit.tmLanguage")
 
+        commit_on_close = savvy_settings.get("commit_on_close")
         title = COMMIT_TITLE.format(os.path.basename(repo_path))
         view.set_name(title)
-        if not savvy_settings.get("prompt_on_abort_commit"):
+        if commit_on_close or not savvy_settings.get("prompt_on_abort_commit"):
             view.set_scratch(True)
         view.run_command("gs_commit_initialize_view")
 

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -65,6 +65,8 @@ class GsCommitCommand(WindowCommand, GitCommand):
             view.set_syntax_file("Packages/GitSavvy/syntax/make_commit.tmLanguage")
 
         commit_on_close = savvy_settings.get("commit_on_close")
+        view.settings().set("git_savvy.commit_on_close", commit_on_close)
+
         title = COMMIT_TITLE.format(os.path.basename(repo_path))
         view.set_name(title)
         if commit_on_close or not savvy_settings.get("prompt_on_abort_commit"):


### PR DESCRIPTION
This PR attempts to fix #293 by explicitly passing the message on view close. It is my understanding that when run_async is called, the original view is not guaranteed to exist anymore, hence the exception seen by @laggingreflex.

Additionally, I made sure that `prompt_on_abort_commit` setting does not prevent `commit_on_close` setting, as well as added a condition to Super/Ctrl+Enter keymap to prevent GitSavvy from attempting a double commit.