### PR TITLE
Enhancement: Prompt for git reset mode

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -233,5 +233,11 @@
         "rebase",
         "tags",
         "graph"
-    ]
+    ],
+
+    /*
+        Set this value to a valid git reset mode (e.g. --hard, --soft) to skip
+        reset mode prompt and always use that reset mode.
+     */
+    "use_reset_mode": null
 }

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -12,7 +12,9 @@ This command will also be suggested to you should you attempt to run a GitSavvy 
 
 This command will change the HEAD of the current branch to a previous commit.
 
-When run, you will be asked to select a commit from a list of previous commits. Once you select a commit, the HEAD of the current branch will be changed to the selected commit, and any changes that were committed after the selected commit will appear as unstaged changes in the working directory.
+When run, you will be asked to select a commit from a list of previous commits. Once you select a commit, you will prompted for a reset mode. Once you select a reset mode the HEAD of the current branch will be changed to the selected commit, and your index and working directory will be updated depending on the reset mode you selected. For more information about reset modes, see the [git reset documentation](https://git-scm.com/docs/git-reset).
+
+To always use a specific reset mode, set `use_reset_mode` to a valid git reset mode flag (e.g. `--soft`, `--hard`) in `Packages/User/GitSavvy.sublime-settings`.
 
 ## `git: reset (reflog)`
 


### PR DESCRIPTION
This commit adds an extra step to the `git: reset` and `git: reset (reflog)` commands that prompts for the git reset mode (e.g. --soft, --hard). By default this step is disabled, and can be enabled by setting `prompt_for_reset_mode` to `true` in GitSavvy.sublime-settings.

Closes #304 

![ezgif com-video-to-gif](https://cloud.githubusercontent.com/assets/912471/11570068/1e891fc0-99ed-11e5-88be-a84f5212be1d.gif)