### PR TITLE
Fix: Incorrect syntax highlighting in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -122,7 +122,7 @@ If you run into any issues not addressed here, please feel free to [open an issu
 
 If you have the need, you can add your own commands that take advantage of GitSavvy's access to your repo.  To do so, create a new `User.sublime-commands` file in your `User` Package directory.  Then, add an entry like so:
 
-```json
+```javascript
 [
     {
         "caption": "git: pull --rebase",
@@ -132,7 +132,7 @@ If you have the need, you can add your own commands that take advantage of GitSa
             "args": ["pull", "--rebase"],
             "start_msg": "Starting pull (rebase)...",
             "complete_msg": "Pull complete.",
-            "run_in_thread": false  # SEE WARNING BELOW
+            "run_in_thread": false  // SEE WARNING BELOW
         }
     }
 ]


### PR DESCRIPTION
Small nitpicky fix, comment in settings JSON example used python comment delimiter `#` instead of JS comment delimiter `//`. Additionally, comments aren't valid syntax in a Github Flavoured Markdown `json` code blocks, so changed the highlighting mode to `javascript`.

<img width="583" alt="screen shot 2015-12-03 at 22 44 53" src="https://cloud.githubusercontent.com/assets/912471/11576757/fc6bf3bc-9a10-11e5-9208-48ac0535b820.png">
