### PR TITLE
fix get_rel_path

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -267,7 +267,7 @@ class GitCommand(StatusMixin,
         Return the file path relative to the repo root.
         """
         path = abs_path or self.file_path
-        return os.path.relpath(path, start=self.repo_path)
+        return os.path.relpath(os.path.realpath(path), start=os.path.realpath(self.repo_path))
 
     def _include_global_flags(self, args):
         """


### PR DESCRIPTION
If the repo is symlinked and the file opened from the symlinked directory, `get_rel_path` doesn't work.

`self.repo_path` shows the real directory but `path` is in terms of the symlink directory.