### PR TITLE
Fix: Syntax files don't match short SHA1 refs longer than 7

### DIFF
--- a/syntax/branch.YAML-tmLanguage
+++ b/syntax/branch.YAML-tmLanguage
@@ -23,7 +23,7 @@ patterns:
     match: '(ahead)|(behind)'
   - comment: head summary
     name: comment.git-savvy.status.head-commit
-    match: '^  HEAD:    ([0-9a-f]{7}) .+'
+    match: '^  HEAD:    ([0-9a-f]{7,40}) .+'
     captures:
       '1': { name: constant.other.git-savvy.status.sha1 }
 
@@ -35,11 +35,11 @@ patterns:
   end: '^$'
   patterns:
   - name: meta.git-savvy.branches.branch
-    match: '^    [0-9a-f]{7} [^ ]+( .*)\n$'
+    match: '^    [0-9a-f]{7,40} [^ ]+( .*)\n$'
     captures:
       '1': { name: comment.git-savvy.branches.branch.extra-info }
   - name: string.other.git-savvy.branches.active-branch
-    match: '^  ▸ [0-9a-f]{7} [^ ]+( .*)\n$'
+    match: '^  ▸ [0-9a-f]{7,40} [^ ]+( .*)\n$'
     captures:
       '1': { name: comment.git-savvy.branches.branch.extra-info }
 

--- a/syntax/branch.tmLanguage
+++ b/syntax/branch.tmLanguage
@@ -63,7 +63,7 @@
 					<key>comment</key>
 					<string>head summary</string>
 					<key>match</key>
-					<string>^  HEAD:    ([0-9a-f]{7}) .+</string>
+					<string>^  HEAD:    ([0-9a-f]{7,40}) .+</string>
 					<key>name</key>
 					<string>comment.git-savvy.status.head-commit</string>
 				</dict>
@@ -98,7 +98,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^    [0-9a-f]{7} [^ ]+( .*)\n$</string>
+					<string>^    [0-9a-f]{7,40} [^ ]+( .*)\n$</string>
 					<key>name</key>
 					<string>meta.git-savvy.branches.branch</string>
 				</dict>
@@ -112,7 +112,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^  ▸ [0-9a-f]{7} [^ ]+( .*)\n$</string>
+					<string>^  ▸ [0-9a-f]{7,40} [^ ]+( .*)\n$</string>
 					<key>name</key>
 					<string>string.other.git-savvy.branches.active-branch</string>
 				</dict>

--- a/syntax/rebase.YAML-tmLanguage
+++ b/syntax/rebase.YAML-tmLanguage
@@ -31,7 +31,7 @@ patterns:
   match: '    ┻'
 
 - name: comment.git-savvy.rebase-graph.base
-  match: '    ┳ \(([0-9a-f]{7})\)'
+  match: '    ┳ \(([0-9a-f]{7,40})\)'
   captures:
     '1':
       name: support.type.git-savvy.rebase.commit_hash
@@ -41,7 +41,7 @@ patterns:
   match: '\*\* [^\*]+ \*\*'
 
 - name: meta.git-savvy.rebase-graph.entry
-  match: '  ([▸ ]) (·)  ([0-9a-f]{7})  (.*)\n'
+  match: '  ([▸ ]) (·)  ([0-9a-f]{7,40})  (.*)\n'
   captures:
     '1':
       name: string.other.git-savvy.rebase.caret
@@ -49,7 +49,7 @@ patterns:
       name: support.type.git-savvy.rebase.commit_hash
 
 - name: meta.git-savvy.rebase-graph.entry
-  match: '  ([▸ ]) (✔)  ([0-9a-f]{7})  (.*)\n'
+  match: '  ([▸ ]) (✔)  ([0-9a-f]{7,40})  (.*)\n'
   captures:
     '1':
       name: string.other.git-savvy.rebase.caret
@@ -59,7 +59,7 @@ patterns:
       name: support.type.git-savvy.rebase.commit_hash
 
 - name: meta.git-savvy.rebase-graph.entry
-  match: '  ([▸ ]) (✕)  ([0-9a-f]{7})  (.*)\n'
+  match: '  ([▸ ]) (✕)  ([0-9a-f]{7,40})  (.*)\n'
   captures:
     '1':
       name: string.other.git-savvy.rebase.caret

--- a/syntax/rebase.tmLanguage
+++ b/syntax/rebase.tmLanguage
@@ -78,7 +78,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>    ┳ \(([0-9a-f]{7})\)</string>
+			<string>    ┳ \(([0-9a-f]{7,40})\)</string>
 			<key>name</key>
 			<string>comment.git-savvy.rebase-graph.base</string>
 		</dict>
@@ -105,7 +105,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>  ([▸ ]) (·)  ([0-9a-f]{7})  (.*)\n</string>
+			<string>  ([▸ ]) (·)  ([0-9a-f]{7,40})  (.*)\n</string>
 			<key>name</key>
 			<string>meta.git-savvy.rebase-graph.entry</string>
 		</dict>
@@ -129,7 +129,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>  ([▸ ]) (✔)  ([0-9a-f]{7})  (.*)\n</string>
+			<string>  ([▸ ]) (✔)  ([0-9a-f]{7,40})  (.*)\n</string>
 			<key>name</key>
 			<string>meta.git-savvy.rebase-graph.entry</string>
 		</dict>
@@ -153,7 +153,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>  ([▸ ]) (✕)  ([0-9a-f]{7})  (.*)\n</string>
+			<string>  ([▸ ]) (✕)  ([0-9a-f]{7,40})  (.*)\n</string>
 			<key>name</key>
 			<string>meta.git-savvy.rebase-graph.entry</string>
 		</dict>

--- a/syntax/status.YAML-tmLanguage
+++ b/syntax/status.YAML-tmLanguage
@@ -23,7 +23,7 @@ patterns:
     match: '(ahead)|(behind)'
   - comment: head summary
     name: comment.git-savvy.status.head-commit
-    match: '^  HEAD:    ([0-9a-f]{7} )?.+'
+    match: '^  HEAD:    ([0-9a-f]{7,40} )?.+'
     captures:
       '1': { name: constant.other.git-savvy.status.sha1 }
 

--- a/syntax/status.tmLanguage
+++ b/syntax/status.tmLanguage
@@ -63,7 +63,7 @@
 					<key>comment</key>
 					<string>head summary</string>
 					<key>match</key>
-					<string>^  HEAD:    ([0-9a-f]{7} )?.+</string>
+					<string>^  HEAD:    ([0-9a-f]{7,40} )?.+</string>
 					<key>name</key>
 					<string>comment.git-savvy.status.head-commit</string>
 				</dict>

--- a/syntax/tags.YAML-tmLanguage
+++ b/syntax/tags.YAML-tmLanguage
@@ -23,7 +23,7 @@ patterns:
     match: '(ahead)|(behind)'
   - comment: head summary
     name: comment.git-savvy.tags.head-commit
-    match: '^  HEAD:    ([0-9a-f]{7}) .+'
+    match: '^  HEAD:    ([0-9a-f]{7,40}) .+'
     captures:
       '1': { name: constant.other.git-savvy.tags.sha1 }
 
@@ -35,7 +35,7 @@ patterns:
   end: '^$'
   patterns:
   - name: meta.git-savvy.tags.tag
-    match: '^    ([0-9a-f]{7}) .+\n$'
+    match: '^    ([0-9a-f]{7,40}) .+\n$'
     captures:
       '1': { name: constant.other.git-savvy.tags.sha1 }
 
@@ -48,7 +48,7 @@ patterns:
   end: '^$'
   patterns:
   - name: meta.git-savvy.tags.tag
-    match: '^    ([0-9a-f]{7}) .+\n$'
+    match: '^    ([0-9a-f]{7,40}) .+\n$'
     captures:
       '1': { name: constant.other.git-savvy.tags.sha1 }
 

--- a/syntax/tags.tmLanguage
+++ b/syntax/tags.tmLanguage
@@ -63,7 +63,7 @@
 					<key>comment</key>
 					<string>head summary</string>
 					<key>match</key>
-					<string>^  HEAD:    ([0-9a-f]{7}) .+</string>
+					<string>^  HEAD:    ([0-9a-f]{7,40}) .+</string>
 					<key>name</key>
 					<string>comment.git-savvy.tags.head-commit</string>
 				</dict>
@@ -98,7 +98,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^    ([0-9a-f]{7}) .+\n$</string>
+					<string>^    ([0-9a-f]{7,40}) .+\n$</string>
 					<key>name</key>
 					<string>meta.git-savvy.tags.tag</string>
 				</dict>
@@ -138,7 +138,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>^    ([0-9a-f]{7}) .+\n$</string>
+					<string>^    ([0-9a-f]{7,40}) .+\n$</string>
 					<key>name</key>
 					<string>meta.git-savvy.tags.tag</string>
 				</dict>


### PR DESCRIPTION
Git will only generate short SHA1 refs that are 7 characters long if the 7 character ref is unambiguous. For larger repositories Git will begin to generate larger short SHA1 refs to keep refs unambiguous. This fix allows GitSavvy to correctly highlight refs longer than 7 characters.

See http://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1 for more information.

Closes #323.