### PR TITLE
Feature: smart tag based on semantic versioning

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -213,6 +213,21 @@
         "command": "gs_tag_create"
     },
     {
+        "caption": "git: quick tag patch",
+        "command": "gs_tag_create",
+        "args": { "release": "patch" }
+    },
+    {
+        "caption": "git: quick tag minor",
+        "command": "gs_tag_create",
+        "args": { "release": "minor" }
+    },
+    {
+        "caption": "git: quick tag major",
+        "command": "gs_tag_create",
+        "args": { "release": "major" }
+    },
+    {
         "caption": "git: branch",
         "command": "gs_show_branch"
     },


### PR DESCRIPTION
**tl;dr** "quick tag" is not quick enough.
Smart tag by adding one to to the right part of the last tag.
For example, if the last tag is "v0.4.5", "tag patch" yields "v0.4.6", "tag minor" yields "v0.5.0" and "tag major" yeilds "v1.0.0".