### PR TITLE
prerelease tag name support

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -217,19 +217,8 @@
         "command": "gs_tag_create"
     },
     {
-        "caption": "git: quick tag patch",
-        "command": "gs_tag_create",
-        "args": { "release": "patch" }
-    },
-    {
-        "caption": "git: quick tag minor",
-        "command": "gs_tag_create",
-        "args": { "release": "minor" }
-    },
-    {
-        "caption": "git: quick tag major",
-        "command": "gs_tag_create",
-        "args": { "release": "major" }
+        "caption": "git: smart tag",
+        "command": "gs_smart_tag"
     },
     {
         "caption": "git: branch",

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -25,3 +25,13 @@ class TagsMixin():
         entries = [TagDetails(entry[:40], entry[51:]) for entry in iter(porcelain_entries) if entry]
 
         return entries
+
+    def get_lastest_local_tag(self):
+        """
+        Return the latest tag. get_tags() fails to return an ordered list.
+        """
+
+        sha = self.git("rev-list", "--tags", "--max-count=1").strip()
+        tag = self.git("describe", "--tags", sha, throw_on_stderr=False).strip()
+
+        return tag

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -24,26 +24,64 @@ TAG_CREATE_MESSAGE_PROMPT = "Enter message:"
 START_PUSH_MESSAGE = "Pushing tag..."
 END_PUSH_MESSAGE = "Push complete."
 
+RELEASE_REGEXP = re.compile(r"^([0-9A-Za-z-]*[A-Za-z-])?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9]+))?$")
 
-def smart_incremented_tag(tag, release):
+def smart_incremented_tag(tag, release_type):
     """
     Automatic increment of a given tag depending on the type of release.
+
+    >>> smart_incremented_tag('v1.3.2', "prerelease") == 'v1.3.3-0'
+    >>> smart_incremented_tag('v1.3.2', "prepatch") == 'v1.3.3-0'
+    >>> smart_incremented_tag('v1.3.2', "preminor") == 'v1.4.0-0'
+    >>> smart_incremented_tag('v1.3.2', "premajor") == 'v2.0.0-0'
+    >>> smart_incremented_tag('v1.3.2', "patch") == 'v1.3.3'
+    >>> smart_incremented_tag('v1.3.2', "minor") == 'v1.4.0'
+    >>> smart_incremented_tag('v1.3.2', "major") == 'v2.0.0'
+    >>> smart_incremented_tag('v1.3.2-1', "prerelease") == 'v1.3.2-2'
+    >>> smart_incremented_tag('v1.3.2-1', "prepatch") == 'v1.3.3-0'
+    >>> smart_incremented_tag('v1.3.2-1', "preminor") == 'v1.4.0-0'
+    >>> smart_incremented_tag('v1.3.2-1', "premajor") == 'v2.0.0-0'
+    >>> smart_incremented_tag('v1.3.2-1', "patch") == 'v1.3.2'
+    >>> smart_incremented_tag('v1.3.2-1', "minor") == 'v1.4.0'
+    >>> smart_incremented_tag('v1.3.2-1', "major") == 'v2.0.0'
+    >>> smart_incremented_tag('v1.3.0-1', "patch") == 'v1.3.0'
+    >>> smart_incremented_tag('v1.3.0-1', "minor") == 'v1.3.0'
+    >>> smart_incremented_tag('v1.3.0-1', "major") == 'v2.0.0'
+    >>> smart_incremented_tag('v1.0.0-1', "major") == 'v1.0.0'
+
     """
-    r = re.compile(r"^([0-9A-Za-z-]*[A-Za-z-])*?([0-9]+)\.([0-9]+)\.([0-9]+)(.*?)$")
-    m = r.match(tag)
+
+    m = RELEASE_REGEXP.match(tag)
     if m:
-        prefix, major, minor, patch, _ = m.groups()
+        prefix, major, minor, patch, prerelease = m.groups()
         prefix = "" if not prefix else prefix
-        if release == "major":
+
+        if release_type == "premajor" \
+                or (not prerelease and release_type == "major") \
+                or (prerelease and release_type == "major" and (minor != "0" or patch != "0")):
             major = str(int(major)+1)
             minor = patch = "0"
-        elif release == "minor":
+            prerelease = None
+        elif release_type == "preminor" \
+                or (not prerelease and release_type == "minor") \
+                or (prerelease and release_type == "minor" and patch != "0"):
             minor = str(int(minor)+1)
             patch = "0"
-        elif release == "patch":
+            prerelease = None
+        elif release_type == "prepatch" \
+                or (not prerelease and release_type == "prerelease") \
+                or (not prerelease and release_type == "patch"):
             patch = str(int(patch)+1)
-        return prefix + major + "." + minor + "." + patch
+            prerelease = None
+
+        if "pre" in release_type[0:3]:
+            prerelease = str(int(prerelease)+1) if prerelease else "0"
+            return prefix + major + "." + minor + "." + patch + "-" + prerelease
+        else:
+            return prefix + major + "." + minor + "." + patch
+
     return None
+
 
 
 class GsShowTagsCommand(WindowCommand, GitCommand):
@@ -275,28 +313,16 @@ class GsTagCreateCommand(TextCommand, GitCommand):
     Through a series of panels, allow the user to add a tag and message.
     """
 
-    def run(self, edit, release=None):
+    def run(self, edit, tag_name=None):
         self.window = self.view.window()
-        self.release = release
+        self.tag_name = tag_name
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
         """
         Prompt the user for a tag name.
         """
-        if not self.release:
-            self.window.show_input_panel(TAG_CREATE_PROMPT, "", self.on_entered_name, None, None)
-        else:
-            tagname = None
-            local_tags = self.get_tags(reverse=True)
-            if local_tags:
-                last_tagname = local_tags[0].tag.replace("refs/tags/", "")
-                tagname = smart_incremented_tag(last_tagname, self.release)
-
-            if tagname:
-                self.on_entered_name(tagname)
-            else:
-                sublime.error_message(TAG_PARSE_FAIL_MESSAGE)
+        self.window.show_input_panel(TAG_CREATE_PROMPT, self.tag_name, self.on_entered_name, None, None)
 
     def on_entered_name(self, tag_name):
         """
@@ -339,6 +365,46 @@ class GsTagCreateCommand(TextCommand, GitCommand):
         sublime.status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
         util.view.refresh_gitsavvy(self.view)
 
+
+class GsSmartTagCommand(TextCommand, GitCommand):
+    """
+    Displays a panel of possible smart tag options, based on the choice,
+    tag the current commit with the corresponding tagname.
+    """
+
+    release_types = [
+        "major",
+        "minor",
+        "patch",
+        "premajor",
+        "preminor",
+        "prepatch",
+        "prerelease"
+    ]
+
+    def run(self, edit):
+        sublime.set_timeout_async(self.run_async)
+
+    def run_async(self):
+        self.view.window().show_quick_panel(self.release_types, self.on_tag)
+
+    def on_tag(self, action):
+        if action < 0:
+            return
+
+        release_type = self.release_types[action]
+
+        tag_name = None
+        local_tags = self.get_tags(reverse=True)
+        if local_tags:
+            last_tag_name = local_tags[0].tag.replace("refs/tags/", "")
+            tag_name = smart_incremented_tag(last_tag_name, release_type)
+
+        if not tag_name:
+            sublime.error_message(TAG_PARSE_FAIL_MESSAGE)
+            return
+
+        self.view.run_command("gs_tag_create", {"tag_name": tag_name})
 
 
 class GsTagPushCommand(TextCommand, GitCommand):

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -395,9 +395,8 @@ class GsSmartTagCommand(TextCommand, GitCommand):
         release_type = self.release_types[action]
 
         tag_name = None
-        local_tags = self.get_tags(reverse=True)
-        if local_tags:
-            last_tag_name = local_tags[0].tag.replace("refs/tags/", "")
+        last_tag_name = self.get_lastest_local_tag()
+        if last_tag_name:
             tag_name = smart_incremented_tag(last_tag_name, release_type)
 
         if not tag_name:


### PR DESCRIPTION
Two changes.

1. add per-release support, if the last tag is in form of `2.3.5-alpha.1`, `0.7.2-rc.10`, the last set of number will be increased by one: `1.4.6-alpha` to `1.4.6-alpha.1` and `2.3.5-rc.1` to `2.3.5-rc.2`.

2. the `tagname` passes to `show_input_panel` instead of running `on_entered_name` directly. It gives user a chance to modify the tag 

These things may be worth discussions:

1. How we should allow user to jump from a pre-release to a regular release. For example, if the last tag is 
`0.7.2-rc.10`, should "git: quick tag patch" yields "0.7.2"? how about "tag minor" and "tag major"?
2. on the other hand, if the last tag is a regular release, say `1.4.6`, should "git: quick tag prerelease" yields `1.4.6-alpha`? how about "beta" and "rc"?
3. other forms of prereleases? there is million ways to specify a pre-release, for examples,
`1.0.0-0.3.7`, `1.0.0-alpha+001`. How about build numbers? `1.0.0+20130313144700`, `1.0.0-beta+exp.sha.5114f85`