### PR TITLE
Feature: allow prompt to specify custom command argument

### DIFF
--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -27,6 +27,23 @@ class GsCustomCommand(WindowCommand, GitCommand):
     """
 
     def run(self, **kwargs):
+        if not kwargs.get('args'):
+            sublime.error_message("Custom command must provide args.")
+            return
+
+        # prompt for custom command argument
+        if '{PROMPT_ARG}' in kwargs.get('args'):
+            prompt_msg = kwargs.pop("prompt_msg", "Command argument: ")
+            return self.window.show_input_panel(
+                prompt_msg,
+                "",
+                lambda arg: sublime.set_timeout_async(
+                    lambda: self.run_async(custom_argument=arg, **kwargs), 0
+                ),
+                None,
+                None
+            )
+
         sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
 
     def run_async(self,
@@ -34,16 +51,16 @@ class GsCustomCommand(WindowCommand, GitCommand):
                   args=None,
                   start_msg="Starting custom command...",
                   complete_msg="Completed custom command.",
-                  run_in_thread=False):
-
-        if not args:
-            sublime.error_message("Custom command must provide args.")
+                  run_in_thread=False,
+                  custom_argument=None):
 
         for idx, arg in enumerate(args):
             if arg == "{REPO_PATH}":
                 args[idx] = self.repo_path
             elif arg == "{FILE_PATH}":
                 args[idx] = self.file_path
+            elif arg == "{PROMPT_ARG}":
+                args[idx] = custom_argument
 
         sublime.status_message(start_msg)
         if run_in_thread:

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ If you run into any issues not addressed here, please feel free to [open an issu
 
 ## Custom Commands
 
-If you have the need, you can add your own commands that take advantage of GitSavvy's access to your repo.  To do so, create a new `User.sublime-commands` file in your `User` Package directory.  Then, add an entry like so:
+If you have the need, you can add your own commands that take advantage of GitSavvy's access to your repo. To do so, create a new `User.sublime-commands` file in your `User` Package directory.  Then, add an entry like so:
 
 ```javascript
 [
@@ -128,35 +128,16 @@ If you have the need, you can add your own commands that take advantage of GitSa
         "caption": "git: pull --rebase",
         "command": "gs_custom",
         "args": {
-            "output_to_panel": true,           
+            "output_to_panel": true,
             "args": ["pull", "--rebase"],
             "start_msg": "Starting pull (rebase)...",
-            "complete_msg": "Pull complete.",
-            "run_in_thread": false  // SEE WARNING BELOW
+            "complete_msg": "Pull complete."
         }
     }
 ]
 ```
 
-### Arguments
-
-Your custom command may be further customized by setting the following arguments:
-
-* `output_to_panel` - send the command output to a panel when complete
-* `args`            - arguments to pass to the `git` command
-
-      GitSavvy also supports some basic interpolation when specifying your `args`. If one of these strings is provided as an element of your `args` array, the appropriate string will be substituted. The following strings are currently supported:
-      
-       - `{FILE_PATH}` - the path to the currently opened file.
-       - `{REPO_PATH}` - the path to the currently opened file's repo path.
-
-* `start_msg`       - a message to display in status bar when the command starts
-* `complete_msg`    - a message to display in status bar when the command completes
-* `run_in_thread`   - when true, your command will be run in a separate child thread, independent of the async UI thread
-
-      **:boom: Warning**
-  
-      Take *extra* care when enabling `run_in_thread`; while it can be useful for long running `git` commands, if handled incorrectly, running such a background thread can have undesirable effects.
+For more information see [custom commands documentation](custom.md)
 
 ## [git-flow](https://github.com/nvie/gitflow) Support
 

--- a/docs/custom.md
+++ b/docs/custom.md
@@ -1,0 +1,79 @@
+# Custom commands
+
+GitSavvy provides a flexible "generic" command, which can be used to add any almost any git functionality and call it from sublime, like any other GitSavvy command.
+
+## Usage
+
+Adding new commands is as simple as creating/modifying `User.sublime-commands` file in your `User` Package directory (see [examples below](#examples)):
+
+## Command arguments
+
+Your custom command may be further customized by setting the following arguments:
+
+* `output_to_panel` - send the command output to a panel when complete
+* `args`            - arguments to pass to the `git` command
+
+      GitSavvy also supports some basic interpolation when specifying your `args`. If one of these strings is provided as an element of your `args` array, the appropriate string will be substituted. The following strings are currently supported:
+      
+       - `{FILE_PATH}` - the path to the currently opened file.
+       - `{REPO_PATH}` - the path to the currently opened file's repo path.
+       - `{PROMPT_ARG}` - prompt use to a custom argument
+
+* `start_msg`       - a message to display in status bar when the command starts
+* `complete_msg`    - a message to display in status bar when the command completes
+* `prompt_msg`      - when using "{PROMPT_ARG}" argument in command, this determines the prompt message
+* `run_in_thread`   - when true, your command will be run in a separate child thread, independent of the async UI thread
+
+      **:boom: Warning**
+  
+      Take *extra* care when enabling `run_in_thread`; while it can be useful for long running `git` commands, if handled incorrectly, running such a background thread can have undesirable effects.
+
+
+## Examples
+
+Here are some more real-life examples of custom command usage:
+
+```javascript
+[
+    {
+        "caption": "git: create patch (from last commit)",
+        "command": "gs_custom",
+        "args": {
+            "output_to_panel": true,
+            "args": ["format-patch", "-1"],
+            "start_msg": "Started creating patch",
+            "complete_msg": "Finished creating patch"
+        }
+    },
+    {
+        "caption": "git: apply patch (with current file)",
+        "command": "gs_custom",
+        "args": {
+            "output_to_panel": false,
+            "args": ["apply", "{FILE_PATH}"],
+            "start_msg": "Started applying patch",
+            "complete_msg": "Finished applying patch"
+        }
+    },
+    {
+        "caption": "git: fixup commit",
+        "command": "gs_custom",
+        "args": {
+            "output_to_panel": false,
+            "args": ["commit", "--fixup", "{PROMPT_ARG}"],
+            "prompt_msg": "Commit to fixup: "
+        }
+    },
+    {
+        "caption": "git: gui blame",
+        "command": "gs_custom",
+        "args": {
+            "output_to_panel": false,
+            "args": ["gui", "blame", "{FILE_PATH}"],
+            "start_msg": "Starting gui blame...",
+            "complete_msg": "Gui blame started",
+            "run_in_thread": true  // SEE WARNING ABOVE !
+        }
+    }
+]
+```


### PR DESCRIPTION
This will allow for more dynamic commands to be created.

I moved custom command documentation to it's own custom.md file since it started to grow too much for README index IMO, and also added some more custom command examples to the doc.