### PR TITLE
check tags on current branch only

### DIFF
--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -28,9 +28,8 @@ class TagsMixin():
 
     def get_lastest_local_tag(self):
         """
-        Return the latest tag. get_tags() fails to return an ordered list.
+        Return the latest tag of the current branch. get_tags() fails to return an ordered list.
         """
 
-        sha = self.git("rev-list", "--tags", "--max-count=1", throw_on_stderr=False).strip()
-        tag = self.git("describe", "--tags", sha, throw_on_stderr=False).strip()
+        tag = self.git("describe", "--tags", "--abbrev=0", throw_on_stderr=False).strip()
         return tag


### PR DESCRIPTION
this allows tagging different smart-tags on stable and dev branches.

For example, the stable is tagging v1.2.3 while the dev branch, the next major version, is tagging v2.0.0-1.

This is essentially the PR #333  without the dead code.