### PR TITLE
reorder smart tag order list

### DIFF
--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -136,13 +136,13 @@ class GsSmartTagCommand(TextCommand, GitCommand):
     """
 
     release_types = [
-        "major",
-        "minor",
         "patch",
-        "premajor",
-        "preminor",
+        "minor",
+        "major",
+        "prerelease",
         "prepatch",
-        "prerelease"
+        "preminor",
+        "premajor"
     ]
 
     def run(self, edit):


### PR DESCRIPTION
`patch` and `prerelease` are more frequently used then other options. 