### PR TITLE
Avoid printing trailing spaces from blame output

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -191,11 +191,11 @@ class GsBlameInitializeViewCommand(TextCommand, GitCommand):
                 left = commit_info[i] if i < left_len else left_fallback
                 right = partition[i].contents if i < right_len else right_fallback
                 lineno = partition[i].final_lineno if i < right_len else right_fallback
-                output += "{left: <{left_pad}} | {lineno: >4} {right}\n".format(
-                    left=left,
-                    left_pad=left_pad,
-                    lineno=lineno,
-                    right=right)
+
+                output += "{left: <{left_pad}} |".format(left=left, left_pad=left_pad)
+                if len(right):
+                    output += " {lineno: >4} {right}".format(lineno=lineno, right=right)
+                output += "\n"
 
             yield output
 

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -185,7 +185,6 @@ class GsBlameInitializeViewCommand(TextCommand, GitCommand):
             commit_info = commit_infos[partition[0].commit_hash]
             left_len = len(commit_info)
             right_len = len(partition)
-            total_lines = max(left_len, right_len)
             total_lines = len(max((commit_info, partition), key=len))
 
             for i in range(total_lines):

--- a/syntax/blame.YAML-tmLanguage
+++ b/syntax/blame.YAML-tmLanguage
@@ -7,7 +7,7 @@ hidden: true
 patterns:
 - comment: line
   name: meta.git-savvy.blame-line
-  match: ^([^|]+) (\|) (( |\d){1,4})
+  match: ^([^|]+) (\|)(\n| (( |\d){1,4}))
   captures:
     '1': { name: comment.block.git-savvy.commit-info }
     '2': { name: comment.block.git-savvy.splitter }

--- a/syntax/blame.tmLanguage
+++ b/syntax/blame.tmLanguage
@@ -30,7 +30,7 @@
 			<key>comment</key>
 			<string>line</string>
 			<key>match</key>
-			<string>^([^|]+) (\|) (( |\d){1,4})</string>
+			<string>^([^|]+) (\|)(\n| (( |\d){1,4}))</string>
 			<key>name</key>
 			<string>meta.git-savvy.blame-line</string>
 		</dict>


### PR DESCRIPTION
This pull request changes the blame command to not output unnecessary trailing spaces, if the [Trailing Spaces](https://github.com/SublimeText/TrailingSpaces) package is installed it is quite noticeable.

Before:
![before](https://cloud.githubusercontent.com/assets/2276355/13299039/a16b7cb6-db39-11e5-9a28-503c50c60287.png)

After:
![after](https://cloud.githubusercontent.com/assets/2276355/13299042/a610500c-db39-11e5-867e-4abc51c82084.png)

A superfluous assignment of the variable `total_lines` is also removed.