### PR TITLE
Syntax highlighting for blame output

### DIFF
--- a/syntax/blame.YAML-tmLanguage
+++ b/syntax/blame.YAML-tmLanguage
@@ -14,4 +14,4 @@ patterns:
     '3': { name: keyword.other.git-savvy.line-number }
 - comment: separator
   name: comment.block.git-savvy.separator
-  match: ^\-{40} \| \-+$
+  match: ^\-{40,48} \| \-+$

--- a/syntax/blame.tmLanguage
+++ b/syntax/blame.tmLanguage
@@ -38,7 +38,7 @@
 			<key>comment</key>
 			<string>separator</string>
 			<key>match</key>
-			<string>^\-{40} \| \-+$</string>
+			<string>^\-{40,48} \| \-+$</string>
 			<key>name</key>
 			<string>comment.block.git-savvy.separator</string>
 		</dict>


### PR DESCRIPTION
This enables syntax highlighting for line separators of commit messages spanning 40-48 characters to match what `blame.py` outputs.

For example in commit 40cdf58 the maximum commit line length of `core/git_command.py` is 48 characters and for `core/commands/blame.py` is 40 characters. This causes line separators to be either white or grey (which both look okay).