### PR TITLE
show git status in status-bar when there is no view.

### DIFF
--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -31,7 +31,7 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
 
     def run_async(self):
         # Short-circuit update attempts for files not part of Git repo.
-        if not self.file_path or not self._repo_path(throw_on_stderr=False):
+        if not self._repo_path(throw_on_stderr=False):
             self.view.erase_status("gitsavvy-repo-status")
             return
 


### PR DESCRIPTION
Status bar is erased when there is no view because `self.file_path` is empty. In fact, there is no need to check `self.file_path` because `self._repo_path` already checks that the directory is a git repo.

There is also side effect, not sure if it is a good/bad thing. Status-bar is now shown also in the dashboard pages.

fix #356