### PR TITLE
Goto symbol

### DIFF
--- a/GitSavvy.tmPreferences
+++ b/GitSavvy.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Symbol List</string>
+   <key>scope</key>
+   <string>gitsavvy.gotosymbol</string>
+   <key>settings</key>
+   <dict>
+      <key>showInSymbolList</key>
+      <integer>1</integer>
+   </dict>
+</dict>
+</plist>

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -39,12 +39,12 @@ contexts:
         - match: '^    [0-9a-f]{7,40} ([^ ]+) (.*)\n$'
           scope: meta.git-savvy.branches.branch
           captures:
-            1: meta.toc-list
+            1: gitsavvy.gotosymbol
             2: comment.git-savvy.branches.branch.extra-info
         - match: '^  ▸ [0-9a-f]{7,40} ([^ ]+) (.*)\n$'
           scope: string.other.git-savvy.branches.active-branch
           captures:
-            1: meta.toc-list
+            1: gitsavvy.gotosymbol
             2: comment.git-savvy.branches.branch.extra-info
     - match: '\*\* [^\*]+ \*\*'
       comment: ux note

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -36,14 +36,16 @@ contexts:
         - meta_scope: meta.git-savvy.status.section
         - match: ^$
           pop: true
-        - match: '^    [0-9a-f]{7,40} [^ ]+( .*)\n$'
+        - match: '^    [0-9a-f]{7,40} ([^ ]+) (.*)\n$'
           scope: meta.git-savvy.branches.branch
           captures:
-            1: comment.git-savvy.branches.branch.extra-info
-        - match: '^  ▸ [0-9a-f]{7,40} [^ ]+( .*)\n$'
+            1: meta.toc-list
+            2: comment.git-savvy.branches.branch.extra-info
+        - match: '^  ▸ [0-9a-f]{7,40} ([^ ]+) (.*)\n$'
           scope: string.other.git-savvy.branches.active-branch
           captures:
-            1: comment.git-savvy.branches.branch.extra-info
+            1: meta.toc-list
+            2: comment.git-savvy.branches.branch.extra-info
     - match: '\*\* [^\*]+ \*\*'
       comment: ux note
       scope: support.type.git-savvy.ux-note

--- a/syntax/diff.sublime-syntax
+++ b/syntax/diff.sublime-syntax
@@ -16,26 +16,23 @@ first_line_match: |-
       )
 contexts:
   main:
-
-    - match: '(^(((-{3}) .+)|((\*{3}) .+))$\n?|^(={4}) .+(?= - ))'
+    - match: '(^(-{3}) a/(.+)$\n?)'
       comment: Needs to be first.
       scope: meta.diff.header.from-file
       captures:
-        4: punctuation.definition.from-file.diff
-        6: punctuation.definition.from-file.diff
-        7: punctuation.definition.from-file.diff
-    - match: '(^(\+{3}) .+$\n?| (-) .* (={4})$\n?)'
+        1: punctuation.definition.from-file.diff
+        3: meta.toc-list
+    - match: '(^(\+{3}) b/(.+)$\n)'
       scope: meta.diff.header.to-file
       captures:
-        2: punctuation.definition.to-file.diff
-        3: punctuation.definition.to-file.diff
-        4: punctuation.definition.to-file.diff
+        1: punctuation.definition.to-file.diff
+        3: dont.need.meta.toc-list
 
     - match: ^(@@)\s*(.+?)\s*(@@)($\n?)?
       scope: meta.diff.range.unified
       captures:
         1: punctuation.definition.range.diff
-        2: meta.toc-list.line-number.diff
+        2: punctuation.definition.range.diff
         3: punctuation.definition.range.diff
 
     - match: '(\{)(\+.+?\+)(\})'

--- a/syntax/diff.sublime-syntax
+++ b/syntax/diff.sublime-syntax
@@ -21,12 +21,12 @@ contexts:
       scope: meta.diff.header.from-file
       captures:
         1: punctuation.definition.from-file.diff
-        3: meta.toc-list
+        3: gitsavvy.gotosymbol
     - match: '(^(\+{3}) b/(.+)$\n)'
       scope: meta.diff.header.to-file
       captures:
         1: punctuation.definition.to-file.diff
-        3: dont.need.meta.toc-list
+        3: dont.need.gitsavvy.gotosymbol
 
     - match: ^(@@)\s*(.+?)\s*(@@)($\n?)?
       scope: meta.diff.range.unified

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -40,7 +40,7 @@ contexts:
   message:
     - match: (`.*`)
       comment: by name
-      scope: keyword.by-name.git-savvy
+      scope: keyword.by-name.git-savvy.
     - match: '(?:[Ff]ix(?:e[ds])?|[Rr]esolve[ds]?|[Cc]lose[ds]?)?\s*(?:#\d+|\[.*?\])'
       comment: issue numbers
       scope: string.other.issue.git-savvy

--- a/syntax/rebase.sublime-syntax
+++ b/syntax/rebase.sublime-syntax
@@ -38,18 +38,21 @@ contexts:
       captures:
         1: string.other.git-savvy.rebase.caret
         3: support.type.git-savvy.rebase.commit_hash
+        4: meta.toc-list
     - match: '  ([▸ ]) (✔)  ([0-9a-f]{7,40})  (.*)\n'
       scope: meta.git-savvy.rebase-graph.entry
       captures:
         1: string.other.git-savvy.rebase.caret
         2: entity.name.function.git-savvy.success
         3: support.type.git-savvy.rebase.commit_hash
+        4: meta.toc-list
     - match: '  ([▸ ]) (✕)  ([0-9a-f]{7,40})  (.*)\n'
       scope: meta.git-savvy.rebase-graph.entry
       captures:
         1: string.other.git-savvy.rebase.caret
         2: string.other.git-savvy.conflict
         3: support.type.git-savvy.rebase.commit_hash
+        4: meta.toc-list
     - match: "^  ####"
       comment: Key-bindings menu
       push:

--- a/syntax/rebase.sublime-syntax
+++ b/syntax/rebase.sublime-syntax
@@ -38,21 +38,21 @@ contexts:
       captures:
         1: string.other.git-savvy.rebase.caret
         3: support.type.git-savvy.rebase.commit_hash
-        4: meta.toc-list
+        4: gitsavvy.gotosymbol
     - match: '  ([▸ ]) (✔)  ([0-9a-f]{7,40})  (.*)\n'
       scope: meta.git-savvy.rebase-graph.entry
       captures:
         1: string.other.git-savvy.rebase.caret
         2: entity.name.function.git-savvy.success
         3: support.type.git-savvy.rebase.commit_hash
-        4: meta.toc-list
+        4: gitsavvy.gotosymbol
     - match: '  ([▸ ]) (✕)  ([0-9a-f]{7,40})  (.*)\n'
       scope: meta.git-savvy.rebase-graph.entry
       captures:
         1: string.other.git-savvy.rebase.caret
         2: string.other.git-savvy.conflict
         3: support.type.git-savvy.rebase.commit_hash
-        4: meta.toc-list
+        4: gitsavvy.gotosymbol
     - match: "^  ####"
       comment: Key-bindings menu
       push:

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -18,4 +18,4 @@ contexts:
         - meta_scope: meta.git-savvy.commit-diff
         - match: ^$
           pop: true
-        - include: scope:source.diff
+        - include: scope:git-savvy.diff

--- a/syntax/status.sublime-syntax
+++ b/syntax/status.sublime-syntax
@@ -37,7 +37,8 @@ contexts:
         - match: ^$
           pop: true
         - match: '^  [ \-] (.+)\n$'
-          scope: meta.git-savvy.status.file
+          captures:
+              1: meta.git-savvy.status.file meta.toc-list
     - match: ^  STASHES:$
       comment: Stashes section
       captures:

--- a/syntax/status.sublime-syntax
+++ b/syntax/status.sublime-syntax
@@ -38,7 +38,7 @@ contexts:
           pop: true
         - match: '^  [ \-] (.+)\n$'
           captures:
-              1: meta.git-savvy.status.file meta.toc-list
+              1: meta.git-savvy.status.file gitsavvy.gotosymbol
     - match: ^  STASHES:$
       comment: Stashes section
       captures:

--- a/syntax/tags.sublime-syntax
+++ b/syntax/tags.sublime-syntax
@@ -40,7 +40,7 @@ contexts:
           scope: meta.git-savvy.tags.tag
           captures:
             1: constant.other.git-savvy.tags.sha1
-            2: meta.toc-list
+            2: gitsavvy.gotosymbol
     - match: ^  (REMOTE) \((.+)\):$
       comment: remote section
       captures:
@@ -54,7 +54,7 @@ contexts:
           scope: meta.git-savvy.tags.tag
           captures:
             1: constant.other.git-savvy.tags.sha1
-            2: meta.toc-list
+            2: gitsavvy.gotosymbol
     - match: '\*\* [^\*]+ \*\*'
       comment: ux note
       scope: support.type.git-savvy.ux-note

--- a/syntax/tags.sublime-syntax
+++ b/syntax/tags.sublime-syntax
@@ -36,10 +36,11 @@ contexts:
         - meta_scope: meta.git-savvy.tags.section
         - match: ^$
           pop: true
-        - match: '^    ([0-9a-f]{7,40}) .+\n$'
+        - match: '^    ([0-9a-f]{7,40}) (.+)\n$'
           scope: meta.git-savvy.tags.tag
           captures:
             1: constant.other.git-savvy.tags.sha1
+            2: meta.toc-list
     - match: ^  (REMOTE) \((.+)\):$
       comment: remote section
       captures:
@@ -49,10 +50,11 @@ contexts:
         - meta_scope: meta.git-savvy.tags.section
         - match: ^$
           pop: true
-        - match: '^    ([0-9a-f]{7,40}) .+\n$'
+        - match: '^    ([0-9a-f]{7,40}) (.+)\n$'
           scope: meta.git-savvy.tags.tag
           captures:
             1: constant.other.git-savvy.tags.sha1
+            2: meta.toc-list
     - match: '\*\* [^\*]+ \*\*'
       comment: ux note
       scope: support.type.git-savvy.ux-note


### PR DESCRIPTION
Feature: Use `Goto Symbol` to navigate in all views

We use .tmPreferences to define witch scopes that should be added to SymbolList, by using a custom scope like `gitsavvy.totosymbol` it can not match any other scopes unless the is a theme defines this scope. So all view will look the same way that are doing now.