### PR TITLE
Improve `create pull request` and rename the function `get_remote_branches`

### DIFF
--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -82,7 +82,7 @@ class GsCheckoutRemoteBranchCommand(WindowCommand, GitCommand):
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
-        self.remote_branches = self.get_remote_branches()
+        self.remote_branches = self.list_remote_branches()
         self.window.show_quick_panel(
             self.remote_branches,
             self.on_selection,

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -21,7 +21,6 @@ class GsPullCommand(WindowCommand, GitCommand):
         proceed no further.
         """
         self.remotes = list(self.get_remotes().keys())
-        self.remote_branches = self.get_remote_branches()
 
         pre_selected_idx = (self.remotes.index(self.last_remote_used)
                             if self.last_remote_used in self.remotes
@@ -47,21 +46,17 @@ class GsPullCommand(WindowCommand, GitCommand):
             return
 
         self.selected_remote = self.remotes[remote_index]
-        selected_remote_prefix = self.selected_remote + "/"
 
         # Save the selected remote for automatic selection on next palette command.
         self.last_remote_used = self.selected_remote
 
-        self.branches_on_selected_remote = [
-            branch for branch in self.remote_branches
-            if branch.startswith(selected_remote_prefix)
-        ]
+        self.branches_on_selected_remote = self.list_remote_branches(self.selected_remote)
 
         current_local_branch = self.get_current_branch_name()
 
         try:
             pre_selected_idx = self.branches_on_selected_remote.index(
-                selected_remote_prefix + current_local_branch)
+                self.selected_remote + "/" + current_local_branch)
         except ValueError:
             pre_selected_idx = 0
 

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -73,7 +73,6 @@ class GsPushToBranchCommand(WindowCommand, PushBase):
         proceed no further.
         """
         self.remotes = list(self.get_remotes().keys())
-        self.remote_branches = self.get_remote_branches()
 
         if not self.remotes:
             self.window.show_quick_panel([NO_REMOTES_MESSAGE], None)
@@ -100,18 +99,13 @@ class GsPushToBranchCommand(WindowCommand, PushBase):
 
         self.selected_remote = self.remotes[remote_index]
         self.last_remote_used = self.selected_remote
-        selected_remote_prefix = self.selected_remote + "/"
-
-        self.branches_on_selected_remote = [
-            branch for branch in self.remote_branches
-            if branch.startswith(selected_remote_prefix)
-        ]
+        self.branches_on_selected_remote = self.list_remote_branches(self.selected_remote)
 
         current_local_branch = self.get_current_branch_name()
 
         try:
             pre_selected_idx = self.branches_on_selected_remote.index(
-                selected_remote_prefix + current_local_branch)
+                self.selected_remote + "/" + current_local_branch)
         except ValueError:
             pre_selected_idx = 0
 
@@ -156,7 +150,6 @@ class GsPushToBranchNameCommand(WindowCommand, PushBase):
         proceed no further.
         """
         self.remotes = list(self.get_remotes().keys())
-        self.remote_branches = self.get_remote_branches()
 
         if not self.remotes:
             self.window.show_quick_panel([NO_REMOTES_MESSAGE], None)

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -19,12 +19,15 @@ class RemotesMixin():
         """
         self.git("fetch", "--prune" if prune else None, remote if remote else "--all")
 
-    def get_remote_branches(self):
+    def list_remote_branches(self, remote=None):
         """
-        Return a list of all known branches on remotes.
+        Return a list of all known branches on all remotes, or a specified remote.
         """
         stdout = self.git("branch", "-r", "--no-color")
         branches = [branch.strip() for branch in stdout.split("\n") if branch]
+
+        if remote:
+            branches = [branch for branch in branches if branch.startswith(remote+"/")]
 
         # Clean up "origin/HEAD -> origin/master" to "origin/master" if present.
         for idx, branch_name in enumerate(branches):

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -347,7 +347,6 @@ class GsBranchesConfigureTrackingCommand(TextCommand, GitCommand):
         self.local_branch = segments[1]
 
         self.remotes = list(self.get_remotes().keys())
-        self.remote_branches = self.get_remote_branches()
 
         if not self.remotes:
             self.view.window().show_quick_panel(["There are no remotes available."], None)
@@ -368,16 +367,11 @@ class GsBranchesConfigureTrackingCommand(TextCommand, GitCommand):
             return
 
         self.selected_remote = self.remotes[remote_index]
-        selected_remote_prefix = self.selected_remote + "/"
-
-        self.branches_on_selected_remote = [
-            branch for branch in self.remote_branches
-            if branch.startswith(selected_remote_prefix)
-        ]
+        self.branches_on_selected_remote = self.list_remote_branches(self.selected_remote)
 
         try:
             pre_selected_index = self.branches_on_selected_remote.index(
-                selected_remote_prefix + self.local_branch)
+                self.selected_remote + "/" + self.local_branch)
         except ValueError:
             pre_selected_index = 0
 

--- a/github/commands/configure.py
+++ b/github/commands/configure.py
@@ -19,7 +19,6 @@ class GsConfigureGithubRemoteCommand(WindowCommand, GitCommand):
         proceed no further.
         """
         self.remotes = list(self.get_remotes().keys())
-        self.remote_branches = self.get_remote_branches()
 
         if not self.remotes:
             self.window.show_quick_panel([NO_REMOTES_MESSAGE], None)

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -8,6 +8,9 @@ from .. import git_mixins
 from ...common import interwebs
 from ...common import util
 
+SET_UPSTREAM_PROMPT = ("You have not set an upstream for the active branch.  "
+                       "Would you like to set one?")
+
 
 def create_palette_entry(pr):
     return [
@@ -143,13 +146,33 @@ class GsCreatePullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemot
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
-        base_remote = github.parse_remote(self.get_integrated_remote_url())
-        remote_branch = self.get_active_remote_branch()
-        if not remote_branch:
-            sublime.message_dialog("Unable to determine remote.")
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        if savvy_settings.get("prompt_for_tracking_branch") and not self.get_upstream_for_active_branch():
+            if sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT):
+                self.remotes = list(self.get_remotes().keys())
+
+                if not self.remotes:
+                    self.view.window().show_quick_panel(["There are no remotes available."], None)
+                else:
+                    self.view.window().show_quick_panel(
+                        self.remotes,
+                        self.on_select_remote,
+                        flags=sublime.MONOSPACE_FONT
+                        )
+
         else:
-            owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
-            self.open_comparision_in_browser(base_remote.url, owner, remote_branch.name)
+            remote_branch = self.get_active_remote_branch()
+            if not remote_branch:
+                sublime.message_dialog("Unable to determine remote.")
+            else:
+                status, secondary = self.get_branch_status()
+                if secondary:
+                    sublime.message_dialog(
+                        "Your current branch is different from its remote counterpart. %s" % secondary)
+                else:
+                    base_remote = github.parse_remote(self.get_integrated_remote_url())
+                    owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
+                    self.open_comparision_in_browser(base_remote.url, owner, remote_branch.name)
 
     def open_comparision_in_browser(self, url, owner, branch):
         open_in_browser("{}/compare/{}:{}?expand=1".format(
@@ -157,3 +180,47 @@ class GsCreatePullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemot
             owner,
             branch
         ))
+
+    def on_select_remote(self, remote_index):
+        """
+        After the user selects a remote, display a panel of branches that are
+        present on that remote, then proceed to `on_select_branch`.
+        """
+        # If the user pressed `esc` or otherwise cancelled.
+        if remote_index == -1:
+            return
+
+        self.selected_remote = self.remotes[remote_index]
+        self.branches_on_selected_remote = self.list_remote_branches(self.selected_remote)
+
+        self.current_local_branch = self.get_current_branch_name()
+
+        try:
+            pre_selected_index = self.branches_on_selected_remote.index(
+                self.selected_remote + "/" + self.current_local_branch)
+        except ValueError:
+            pre_selected_index = 0
+
+        self.view.window().show_quick_panel(
+            self.branches_on_selected_remote,
+            self.on_select_branch,
+            flags=sublime.MONOSPACE_FONT,
+            selected_index=pre_selected_index
+        )
+
+    def on_select_branch(self, branch_index):
+        """
+        Determine the actual branch name of the user's selection, and proceed
+        to `do_pull`.
+        """
+        # If the user pressed `esc` or otherwise cancelled.
+        if branch_index == -1:
+            return
+        selected_remote_branch = self.branches_on_selected_remote[branch_index].split("/", 1)[1]
+        remote_ref = self.selected_remote + "/" + selected_remote_branch
+
+        self.current_local_branch = self.get_current_branch_name()
+
+        self.git("branch", "-u", remote_ref, self.current_local_branch)
+
+        sublime.set_timeout_async(self.run_async, 0)


### PR DESCRIPTION
I have renamed `list_remote_branches` to `get_remote_branches` and upgraded the related code 4e3f012.

> `get_branches` and `get_remote_branches` have similar names but have very different outputs.
`get_branches` returns a named tuple `Branch` and `get_remote_branches` returns a list of remote branches names. In order to reduce confusion, `get_remote_branches` is renamed
as `list_remote_branches`. `list_remote_branches` also has a new argument `remote` which
filters the results with a specified remote.

Also, `create pull request` now checks if remote tracking branch has been set.


PS: `on_select_remote` and `on_select_branch` have been used several times, but I couldn't find a easy way to reuse the code.