### PR TITLE
Feature: Cherry-pick from Branch Commit Comparison view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -650,7 +650,7 @@
     },
     {
         "keys": ["H"],
-        "command": "gs_branches_diff_branch_history",
+        "command": "gs_branches_diff_commit_history",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
@@ -829,6 +829,48 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+
+    //////////////////////////////
+    // BRANCH COMMIT COMPARISON //
+    //////////////////////////////
+
+    {
+        "keys": ["enter"],
+        "command": "gs_branches_diff_commit_history_action",
+        "context": [
+            { "key": "setting.git_savvy.branch_commit_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["."],
+        "command": "gs_log_graph_next_commit",
+        "args": {"forward": true},
+        "context": [
+            { "key": "setting.git_savvy.branch_commit_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": [","],
+        "command": "gs_log_graph_next_commit",
+        "args": {"forward": false},
+        "context": [
+            { "key": "setting.git_savvy.branch_commit_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+        {
+        "keys": ["m"],
+        "command": "gs_log_graph_toggle_more_info",
+        "context": [
+            { "key": "setting.git_savvy.branch_commit_history_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["r"],
+        "command": "gs_branches_diff_commit_history_refresh",
+        "context": [
+            { "key": "setting.git_savvy.branch_commit_history_view", "operator": "equal", "operand": true }
         ]
     },
 

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -65,6 +65,9 @@ def refresh_gitsavvy(view):
     """
     if view.settings().get("git_savvy.interface") is not None:
         view.run_command("gs_interface_refresh")
+    if view.settings().get("git_savvy.branch_commit_history_view") is not None:
+        view.run_command("gs_branches_diff_commit_history_refresh")
+
     view.run_command("gs_update_status_bar")
 
 

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -12,6 +12,7 @@ from .init import *
 from .diff import *
 from .blame import *
 from .show_commit import *
+from .branch_commit_history import *
 from .log import *
 from .merge import*
 from .changelog import *

--- a/core/commands/branch_commit_history.py
+++ b/core/commands/branch_commit_history.py
@@ -1,0 +1,130 @@
+import sublime
+from sublime_plugin import TextCommand
+
+from ..git_command import GitCommand
+from ...common import util
+from ...common import ui
+
+
+class GsBranchesDiffCommitHistoryCommand(TextCommand, GitCommand):
+
+    """
+    Show a view of all commits diff between branches.
+    """
+
+    def run(self, edit):
+        sublime.set_timeout_async(self.run_async)
+
+    def run_async(self):
+        self.interface = ui.get_interface(self.view.id())
+        selection, line = self.interface.get_selection_line()
+        if not line:
+            return
+
+        segments = line.strip("▸ ").split(" ")
+        branch_name = segments[1]
+
+        local_region = self.view.get_regions("git_savvy_interface.branch_list")[0]
+        if local_region.contains(selection):
+            self.show_commits(branch_name)
+            return
+
+        remotes = self.get_remotes()
+        for remote_name in remotes:
+            remote_region = self.view.get_regions("git_savvy_interface.branch_list_" + remote_name)
+            if remote_region and remote_region[0].contains(selection):
+                self.show_commits(branch_name, remote=remote_name)
+                return
+
+    def show_commits(self, branch_name, remote=None):
+        view = util.view.get_scratch_view(self, "branch_commit_history", read_only=True)
+
+        view.settings().set("active_branch_name", self.get_current_branch_name())
+        view.settings().set("comparison_branch_name", remote + "/" + branch_name if remote else branch_name)
+
+        view.settings().set("git_savvy.repo_path", self.repo_path)
+        view.settings().set("word_wrap", False)
+        view.set_syntax_file("Packages/GitSavvy/syntax/graph.sublime-syntax")
+        view.set_name("BRANCH COMMIT COMPARISON")
+        view.sel().clear()
+        view.run_command("gs_branches_diff_commit_history_refresh")
+
+
+class GsBranchesDiffCommitHistoryRefreshCommand(TextCommand, GitCommand):
+
+    """
+    Refresh view of all commits diff between branches.
+    """
+
+    def run(self, edit):
+        diff_contents = self.get_commit_branch_string()
+        self.view.run_command("gs_replace_view_text", {"text": diff_contents})
+
+    def get_commit_branch_string(self):
+        branchA = self.view.settings().get("comparison_branch_name")
+        branchB = self.view.settings().get("active_branch_name")
+
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        args = savvy_settings.get("git_graph_args")
+        diff_contents = "Commits on {} and not on {}\n".format(branchA, branchB)
+        args.append("{}..{}".format(branchB, branchA))
+        diff_contents += self.git(*args)
+        diff_contents += "\n\nCommits on {} and not on {}\n".format(branchB, branchA)
+        args.pop()
+        args.append("{}..{}".format(branchA, branchB))
+        diff_contents += self.git(*args)
+        return diff_contents
+
+
+class GsBranchesDiffCommitHistoryActionCommand(TextCommand, GitCommand):
+
+    """
+    Checkout the commit at the selected line.
+    """
+
+    def run(self, edit):
+        self.actions = [
+            "Show commit",
+            "Checkout commit",
+            "Cherry-pick commit",
+            "Refresh (r)",
+         ]
+
+        self.selections = self.view.sel()
+
+        lines = util.view.get_lines_from_regions(self.view, self.selections)
+        line = lines[0]
+        self.commit_hash = line.strip(" /_\|*").split(' ')[0]
+
+        if not len(self.selections) == 1:
+            sublime.status_message("You can only do actions on one commit at a time.")
+            return
+
+        self.view.window().show_quick_panel(
+            self.actions,
+            self.on_select_action,
+            selected_index=self.quick_panel_branch_diff_history_idx,
+            flags=sublime.MONOSPACE_FONT
+        )
+
+    def on_select_action(self, index):
+        if index == -1:
+            return
+        self.quick_panel_branch_diff_history_idx = index
+
+        # Show commit
+        if index == 0:
+            self.view.window().run_command("gs_show_commit", {"commit_hash": self.commit_hash})
+
+        # Checkout commit
+        if index == 1:
+            self.checkout_ref(self.commit_hash)
+            util.view.refresh_gitsavvy(self.view)
+
+        # Cherry-pick  commit
+        if index == 2:
+            self.view.window().run_command("gs_cherry_pick", {"target_hash": self.commit_hash})
+
+        # Refresh
+        if index == 3:
+            util.view.refresh_gitsavvy(self.view)

--- a/core/commands/cherry_pick.py
+++ b/core/commands/cherry_pick.py
@@ -1,13 +1,15 @@
 import sublime
+from sublime_plugin import TextCommand
 
 from .log import GsLogCommand
 from ..git_mixins.branches import BranchesMixin
+from ...common import util
 
 
 class GsCherryPickCommand(GsLogCommand, BranchesMixin):
-    def run_async(self, target_hash=None):
-        if target_hash:
-            return self.cherry_pick(target_hash)
+    def run_async(self):
+        if self._target_hash:
+            return self.cherry_pick(self._target_hash)
 
         self.select_commit = super().run_async
 
@@ -38,3 +40,4 @@ class GsCherryPickCommand(GsLogCommand, BranchesMixin):
         self.git("cherry-pick", commit_hash)
         sublime.status_message("Commit %s cherry-picked successfully." %
                                commit_hash)
+        util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -9,12 +9,13 @@ from ...common import util
 class GsLogCommand(WindowCommand, GitCommand):
     cherry_branch = None
 
-    def run(self, filename=None, limit=6000, author=None, log_current_file=False):
+    def run(self, filename=None, limit=6000, author=None, log_current_file=False, target_hash=None):
         self._pagination = 0
         self._filename = filename
         self._limit = limit
         self._author = author
         self._log_current_file = log_current_file
+        self._target_hash = target_hash
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -68,6 +68,7 @@ class GitCommand(StatusMixin,
     _last_remotes_used = {}
     _quick_panel_blame_idx = 1
     _quick_panel_log_idx = 1
+    _quick_panel_branch_diff_history_idx = 1
 
     def git(self, *args, stdin=None, working_dir=None, show_panel=False, throw_on_stderr=True, decode=True):
         """
@@ -334,3 +335,12 @@ class GitCommand(StatusMixin,
     @quick_panel_log_idx.setter
     def quick_panel_log_idx(self, value):
         self._quick_panel_log_idx = value
+
+    @property
+    def quick_panel_branch_diff_history_idx(self):
+        """ Index for quick panel branch diff commit history options"""
+        return self._quick_panel_branch_diff_history_idx
+
+    @quick_panel_branch_diff_history_idx.setter
+    def quick_panel_branch_diff_history_idx(self, value):
+        self._quick_panel_branch_diff_history_idx = value

--- a/docs/branch_mgmt.md
+++ b/docs/branch_mgmt.md
@@ -88,7 +88,7 @@ A scratch view will be opened, showing the diff between the selected branch and 
 
 #### Diff history of selected and active branches (`H`)
 
-A scratch view will be opened, showing the commit diff between the selected branch and the active branch.
+A scratch view will be opened, showing the commit diff between the selected branch and the active branch. Hitting `Enter` will open a panel where you can choose to `show commit`, `Checkout commit`,  `Cherry-pick commit` and `Refresh`. Refresh is also available by pressing `r`.
 
 #### Toggle display of remote branches (`e`)
 


### PR DESCRIPTION
closes #11

Some of the changes is so Branch Commit Comparison view can be refreshed.

Read my comment on core/commands/cherry_pick.py L28.
Maybe I can rewrite the cherrypick to be defined in BranchesMixin instead, and call that one. This way I we don't need to call the asynk call.