### PR TITLE
Improve: the slow startup time

### DIFF
--- a/git_savvy.py
+++ b/git_savvy.py
@@ -7,7 +7,7 @@ if sys.version_info[0] == 2:
 else:
     def plugin_loaded():
         from .common import util
-        util.file.determine_syntax_files()
+        sublime.set_timeout_async(util.file.determine_syntax_files)
 
         # Ensure all interfaces are ready.
         sublime.set_timeout_async(


### PR DESCRIPTION
Detail: `util.file.determine_syntax_files` has been significantly slowing down the start up time of Sublime Text (at least 6 seconds on my computer).

Solution: use `set_timeout_async` to run it.