### PR TITLE
Ensure Unicode is not decomposed

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -1,5 +1,6 @@
 import re
 from collections import namedtuple, defaultdict
+import unicodedata
 
 import sublime
 from sublime_plugin import WindowCommand, TextCommand
@@ -80,6 +81,7 @@ class GsBlameInitializeViewCommand(TextCommand, GitCommand):
         blame_porcelain = self.git(
             "blame", "-p", ignore_whitespace, detect_move_or_copy, self.file_path
         )
+        blame_porcelain = unicodedata.normalize('NFC', blame_porcelain)
         blamed_lines, commits = self.parse_blame(blame_porcelain.splitlines())
 
         commit_infos = {


### PR DESCRIPTION
Git commit names can contain decomposed Unicode, which causes line length calculation to be incorrect for the output of the blame command. In the below example the "ö" in "Schöne decomposed" is `\x6F\xCC\x88` but in "Schöne original" it is `\xC3\xB6`.

The solution is to normalize the Unicode of the output from the git blame command.

Before:
![before](https://cloud.githubusercontent.com/assets/2276355/15125969/081c21e6-1630-11e6-9e47-f439ecc7ff61.jpg)

After:
![after](https://cloud.githubusercontent.com/assets/2276355/15125971/09124c4c-1630-11e6-9ea9-db820373a4d1.jpg)

