### PR TITLE
dev_mode: Reliable plugin reloads

### DIFF
--- a/common/commands/debug.py
+++ b/common/commands/debug.py
@@ -3,13 +3,12 @@ Sublime commands related to development and debugging.
 """
 
 import sys
-import imp
 import urllib
 
 import sublime
 from sublime_plugin import WindowCommand
 
-from ..util import debug
+from ..util import debug, reload
 
 REPORT_URL_TEMPLATE = "https://github.com/divmain/GitSavvy/issues/new?{q}"
 
@@ -17,31 +16,15 @@ REPORT_URL_TEMPLATE = "https://github.com/divmain/GitSavvy/issues/new?{q}"
 class GsReloadModulesDebug(WindowCommand):
 
     """
-    When triggered, reload all GitSavvy submodules twice, so as not
-    to worry about load order.
+    When triggered, reload all GitSavvy submodules.
     """
 
     def run(self):
+        reload.reload_plugin()
+
+    def is_visible(self):
         savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-
-        if savvy_settings.get("dev_mode"):
-            for _ in range(2):
-                for name in self.ordered_modules():
-                    module = sys.modules[name]
-                    print("GitSavvy: reloading submodule", name)
-                    imp.reload(module)
-
-            sublime.sublime_api.plugin_host_ready()
-
-    def ordered_modules(self):
-        # common.ui must always be loaded first because it sets up the
-        # array of interface listeners.  If it's loaded after any of the
-        # interface modules then refresh events will be broken.
-        modules = ["GitSavvy.common.ui"]
-        modules += [mod for mod in sys.modules.keys()
-                    if mod[0:8] == "GitSavvy" and mod not in modules]
-
-        return modules
+        return savvy_settings.get("dev_mode")
 
 
 class GsStartLoggingCommand(WindowCommand):

--- a/common/util/__init__.py
+++ b/common/util/__init__.py
@@ -8,5 +8,6 @@ from . import log
 from . import actions
 from . import debug
 from . import diff_string
+from . import reload
 
 super_key = "SUPER" if sys.platform == "darwin" else "CTRL"

--- a/common/util/reload.py
+++ b/common/util/reload.py
@@ -1,0 +1,97 @@
+import importlib
+import sys
+from contextlib import contextmanager
+
+import sublime_plugin
+
+
+def reload_plugin():
+    """Reload the GitSavvy plugin among with all its modules."""
+    #
+    # Here's the approach in general:
+    #
+    #   - Hide GitSavvy modules from the sys.modules temporarily;
+    #
+    #   - Install a special import hook onto sys.meta_path;
+    #
+    #   - Call sublime_plugin.reload_plugin(), which imports the main
+    #     "git_savvy" module under the hood, triggering the hook;
+    #
+    #   - The hook, instead of creating a new module object, peeks the saved
+    #     one and reloads it. Once the module encounters an import statement
+    #     requesting another module, not yet reloaded, the hook reenters and
+    #     processes that new module recursively, then get back to the previous
+    #     one, and so on.
+    #
+    # This makes the modules reload in the very same order as they were loaded
+    # initially, as if they were imported from scratch.
+    #
+    from GitSavvy import git_savvy
+
+    sublime_plugin.unload_module(git_savvy)
+
+    modules = {name: module for name, module in sys.modules.items()
+               if name.startswith("GitSavvy.")}
+
+    # Insert the main "git_savvy" module at the beginning to make the reload
+    # order be as close to the order of the "natural" import as possible.
+    module_names = [git_savvy.__name__] + sorted(name for name in modules
+                                                 if name != git_savvy.__name__)
+
+    # First, remove all the loaded modules from the sys.modules cache,
+    # otherwise the reloading hook won't be called.
+    loaded_modules = dict(sys.modules)
+    for name in loaded_modules:
+        if name in modules:
+            del sys.modules[name]
+
+    @FilteringImportHook.when(condition=lambda name: name in modules)
+    def module_reloader(name):
+        module = modules[name]
+        sys.modules[name] = module  # restore the module back
+        print("reloading", name)
+        return module.__loader__.load_module(name)
+
+    with intercepting_imports(module_reloader):
+        # Now, import all the modules back, in order, starting with the main
+        # module. This will reload all the modules directly or indirectly
+        # referenced by the main one, i.e. usually most of our modules.
+        sublime_plugin.reload_plugin(git_savvy.__name__)
+
+        # Be sure to bring back *all* the modules that used to be loaded, not
+        # only these imported through the main one. Otherwise, some of them
+        # might end up being created from scratch as new module objects in
+        # case of being imported after detaching the hook. In general, most of
+        # the imports below (if not all) are no-ops though.
+        for name in module_names:
+            importlib.import_module(name)
+
+
+@contextmanager
+def intercepting_imports(hook):
+    sys.meta_path.insert(0, hook)
+    try:
+        yield hook
+    finally:
+        if hook in sys.meta_path:
+            sys.meta_path.remove(hook)
+
+
+class FilteringImportHook:
+    """
+    PEP-302 importer that delegates loading of given modules to a function.
+    """
+
+    def __init__(self, condition, load_module):
+        super().__init__()
+        self.condition = condition
+        self.load_module = load_module
+
+    @classmethod
+    def when(cls, condition):
+        """A handy loader function decorator."""
+        return lambda load_module: cls(condition, load_module)
+
+    def find_module(self, name, path=None):
+        if self.condition(name):
+            return self


### PR DESCRIPTION
This PR implements reloading modules in a more robust and reliable way using import hooks. The key feature is that the modules get reloaded in the very same order they would be loaded during fresh startup.

Here's a part of debug output showing the proper reload sequence (I don't include debug trace facilities for now though, that is a subject for a separate PR):
```
GS [reload] begin ══════════════════════════════════════════════════════
reloading plugin GitSavvy.git_savvy
GS [reload]  ┡━─ GitSavvy.git_savvy
GS [reload]  ╿ ┡━─ GitSavvy.common
GS [reload]  ╿ ┡━─ GitSavvy.common.commands
GS [reload]  ╿ ╿ ┡━─ GitSavvy.common.commands.debug
GS [reload]  ╿ ╿ ╿ ┡━─ GitSavvy.common.util
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.parse_diff
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.dates
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.view
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.file
GS [reload]  ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor
GS [reload]  ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.error
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.tokens
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.events
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.nodes
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.loader
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.reader
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.scanner
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.parser
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.composer
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.constructor
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.resolver
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.dumper
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.emitter
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.serializer
GS [reload]  ╿ ╿ ╿ ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.vendor.yaml.representer
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.log
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.actions
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.debug
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.diff_string
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.util.reload
GS [reload]  ╿ ╿ ┡━─ GitSavvy.common.commands.log
GS [reload]  ╿ ╿ ┡━─ GitSavvy.common.commands.view_manipulation
GS [reload]  ╿ ╿ ┡━─ GitSavvy.common.commands.help
GS [reload]  ╿ ┡━─ GitSavvy.common.ui
GS [reload]  ╿ ┡━─ GitSavvy.common.global_events
GS [reload]  ╿ ┡━─ GitSavvy.core
GS [reload]  ╿ ┡━─ GitSavvy.core.commands
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.quick_stage
GS [reload]  ╿ ╿ ╿ ┡━─ GitSavvy.core.git_command
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.status
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.active_branch
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.branches
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.stash
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.stage_unstage
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.checkout_discard
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.remotes
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.ignore
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.tags
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.history
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.rewrite
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.core.git_mixins.merge
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.inline_diff
GS [reload]  ╿ ╿ ╿ ┡━─ GitSavvy.common.theme_generator
GS [reload]  ╿ ╿ ╿ ┡━─ GitSavvy.core.constants
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.commit
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.quick_commit
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.log_graph
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.checkout
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.fetch
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.pull
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.push
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.ignore
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.init
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.diff
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.blame
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.show_commit
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.branch_commit_history
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.log
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.merge
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.changelog
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.status_bar
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.reset
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.remote
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.custom
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.flow
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.cherry_pick
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.tag
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.show_file_at_commit
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.git_add
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.commands.navigate
GS [reload]  ╿ ┡━─ GitSavvy.core.interfaces
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.interfaces.status
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.interfaces.branch
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.interfaces.rebase
GS [reload]  ╿ ╿ ┡━─ GitSavvy.core.interfaces.tags
GS [reload]  ╿ ┡━─ GitSavvy.github
GS [reload]  ╿ ┡━─ GitSavvy.github.commands
GS [reload]  ╿ ╿ ┡━─ GitSavvy.github.commands.open_on_remote
GS [reload]  ╿ ╿ ╿ ┡━─ GitSavvy.github.github
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.common.interwebs
GS [reload]  ╿ ╿ ╿ ┡━─ GitSavvy.github.git_mixins
GS [reload]  ╿ ╿ ╿ ╿ ┡━─ GitSavvy.github.git_mixins.remotes
GS [reload]  ╿ ╿ ┡━─ GitSavvy.github.commands.commit
GS [reload]  ╿ ╿ ┡━─ GitSavvy.github.commands.configure
GS [reload]  ╿ ╿ ┡━─ GitSavvy.github.commands.add_fork_as_remote
GS [reload]  ╿ ╿ ┡━─ GitSavvy.github.commands.pull_request
GS [reload] end ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

Please find more detailed info in comments and commit log messages.