### PR TITLE
Feature/custom environ for custom commands

### DIFF
--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -6,18 +6,17 @@ from ..git_command import GitCommand
 from ...common import util
 
 
-ALL_REMOTES = "All remotes."
-
-
 class CustomCommandThread(threading.Thread):
-    def __init__(self, func, *args, **kwargs):
+    def __init__(self, func, *args, custom_environ=None, **kwargs):
+        self.custom_environ = custom_environ
         super(CustomCommandThread, self).__init__(**kwargs)
         self.cmd_args = args
         self.cmd_func = func
         self.daemon = True
 
     def run(self):
-        return self.cmd_func(*self.cmd_args)
+        return self.cmd_func(*self.cmd_args,
+                             custom_environ=self.custom_environ)
 
 
 class GsCustomCommand(WindowCommand, GitCommand):
@@ -52,7 +51,8 @@ class GsCustomCommand(WindowCommand, GitCommand):
                   start_msg="Starting custom command...",
                   complete_msg="Completed custom command.",
                   run_in_thread=False,
-                  custom_argument=None):
+                  custom_argument=None,
+                  custom_environ=None):
 
         for idx, arg in enumerate(args):
             if arg == "{REPO_PATH}":
@@ -65,10 +65,10 @@ class GsCustomCommand(WindowCommand, GitCommand):
         sublime.status_message(start_msg)
         if run_in_thread:
             stdout = ''
-            cmd_thread = CustomCommandThread(self.git, *args)
+            cmd_thread = CustomCommandThread(self.git, *args, custom_environ=custom_environ)
             cmd_thread.start()
         else:
-            stdout = self.git(*args)
+            stdout = self.git(*args, custom_environ=custom_environ)
         sublime.status_message(complete_msg)
 
         if output_to_panel:

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -70,7 +70,13 @@ class GitCommand(StatusMixin,
     _quick_panel_log_idx = 1
     _quick_panel_branch_diff_history_idx = 1
 
-    def git(self, *args, stdin=None, working_dir=None, show_panel=False, throw_on_stderr=True, decode=True):
+    def git(self, *args,
+            stdin=None,
+            working_dir=None,
+            show_panel=False,
+            throw_on_stderr=True,
+            decode=True,
+            custom_environ=None):
         """
         Run the git command specified in `*args` and return the output
         of the git command as a string.
@@ -117,12 +123,14 @@ class GitCommand(StatusMixin,
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+            environ = os.environ.copy()
+            environ.update(custom_environ or {})
             p = subprocess.Popen(command,
                                  stdin=subprocess.PIPE,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE,
                                  cwd=working_dir or self.repo_path,
-                                 env=os.environ,
+                                 env=environ,
                                  startupinfo=startupinfo)
             stdout, stderr = p.communicate(stdin.encode(encoding="UTF-8") if stdin else None)
             if decode:


### PR DESCRIPTION
This is a pretty selfish feature. I found myself running rebase in shell for squashing fixup commits, e.g `git rebase -i --autosquash origin` and just found out that I could do this non-interactively if setting a non-interactive EDITOR environment variable.

I wanted to add a custom commands and found I couldn't. Here's an example custom command:


    {
        "caption": "git: rebase fixup commits",
        "command": "gs_custom",
        "args": {
            "output_to_panel": true,
            "args": ["rebase", "-p", "-i", "--autosquash", "{PROMPT_ARG}"],
            "custom_environ": {"EDITOR": "cat"},
            "prompt_msg": "Rebase from commit: "
        }
    }