### PR TITLE
Syntax improvements for custom color schemes

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -7,7 +7,7 @@ from ..git_command import GitCommand
 from ...common import util
 
 
-COMMIT_HELP_TEXT_EXTRA = """
+COMMIT_HELP_TEXT_EXTRA = """##
 ## You may also reference or close a GitHub issue with this commit.  To do so,
 ## type `#` followed by the `tab` key.  You will be shown a list of issues
 ## related to the current repo.  You may also type `owner/repo#` plus the `tab`

--- a/syntax/branch.sublime-syntax
+++ b/syntax/branch.sublime-syntax
@@ -56,7 +56,8 @@ contexts:
       comment: Key-bindings menu
       push:
         - meta_scope: comment.git-savvy.status.key-bindings-menu
-        - match: ^-$
+        - match: ^-\n$
+          scope: comment.git-savvy.key-bindings-menu.end
           pop: true
         - match: "  ## ([A-Z ]+) ##"
           scope: meta.git-savvy.key-bindings-header

--- a/syntax/make_commit.sublime-syntax
+++ b/syntax/make_commit.sublime-syntax
@@ -12,7 +12,7 @@ contexts:
     - match: '(\w+/\w+)?#[0-9]+'
       comment: issue
       scope: constant.other.git-savvy.make-commit.issue-ref
-    - match: ^#{1,2}.*
+    - match: ^#{1,2}.*\n$
       comment: commit header
       scope: comment.git-savvy.make-commit
     - match: ^(?=diff --git)

--- a/syntax/rebase.sublime-syntax
+++ b/syntax/rebase.sublime-syntax
@@ -57,7 +57,8 @@ contexts:
       comment: Key-bindings menu
       push:
         - meta_scope: comment.git-savvy.rebase.key-bindings-menu
-        - match: ^-$
+        - match: ^-\n$
+          scope: comment.git-savvy.key-bindings-menu.end
           pop: true
         - match: "  ## ([A-Z ]+) ##"
           scope: meta.git-savvy.key-bindings-header

--- a/syntax/status.sublime-syntax
+++ b/syntax/status.sublime-syntax
@@ -53,7 +53,8 @@ contexts:
       comment: Key-bindings menu
       push:
         - meta_scope: comment.git-savvy.status.key-bindings-menu
-        - match: ^-$
+        - match: ^-\n$
+          scope: comment.git-savvy.key-bindings-menu.end
           pop: true
         - match: "  ## ([A-Z ]+) ##"
           scope: meta.git-savvy.key-bindings-header

--- a/syntax/tags.sublime-syntax
+++ b/syntax/tags.sublime-syntax
@@ -62,7 +62,8 @@ contexts:
       comment: Key-bindings menu
       push:
         - meta_scope: comment.git-savvy.tags.key-bindings-menu
-        - match: ^-$
+        - match: ^-\n$
+          scope: comment.git-savvy.key-bindings-menu.end
           pop: true
         - match: "  ## ([A-Z ]+) ##"
           scope: meta.git-savvy.key-bindings-header


### PR DESCRIPTION
These are subtle syntax changes to be able to write a better color scheme and create a better UI

-  Adding a spacial scope to the last `-` of the key-binding-menu
   -  The extra \n helps the background color set by color scheme to expand to the
    end of viewport.
-    better commit help section
    - The extra \n helps the background color set by color scheme to expand to
    the end of viewport.
    - the spacing between help section is replace with empty ## to be captured
    by syntax and colored as a single section by color scheme

![screen shot 2016-06-21 at 1 19 44 am](https://cloud.githubusercontent.com/assets/3202/16213312/c0494340-374e-11e6-8a19-d517a3a0629a.png)
![screen shot 2016-06-21 at 1 21 15 am](https://cloud.githubusercontent.com/assets/3202/16213314/c29a2628-374e-11e6-9e4e-209fc005541a.png)
