### PR TITLE
Handle Vintageous in Inline Diff

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -70,6 +70,7 @@ class GsInlineDiffCommand(WindowCommand, GitCommand):
         self.window.focus_view(diff_view)
 
         diff_view.run_command("gs_inline_diff_refresh")
+        diff_view.run_command("gs_handle_vintageous")
 
     def augment_color_scheme(self, target_view, file_ext):
         """


### PR DESCRIPTION
* this view relies heavily on keyboard interaction, it only makes sense
  to enable insert mode if we're vintageous friendly