### PR TITLE
Preventing generated color schemes to appear

### DIFF
--- a/common/theme_generator.py
+++ b/common/theme_generator.py
@@ -66,7 +66,7 @@ class ThemeGenerator():
 
         path_in_packages = os.path.join("User",
                                         "GitSavvy",
-                                        "GitSavvy.{}.tmTheme".format(name))
+                                        "GitSavvy.{}.hidden-tmTheme".format(name))
 
         full_path = os.path.join(sublime.packages_path(), path_in_packages)
 


### PR DESCRIPTION
Preventing generated color schemes to appear in Sublime's color scheme menu.

This is a trick that sublime itself uses to hide some color schemes and syntaxes