### PR TITLE
Enhancement: github: open file and open repo

### DIFF
--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -470,11 +470,7 @@ class GsStatusOpenFileOnRemoteCommand(TextCommand, GitCommand):
             valid_ranges=valid_ranges
         )
         file_paths = tuple(line[4:].strip() for line in lines if line)
-
-        if file_paths:
-            file_paths = list(file_paths)
-            for fpath in file_paths:
-                self.view.run_command("gs_open_file_on_remote", {"fpath": fpath})
+        self.view.run_command("gs_open_file_on_remote", {"fpath": list(file_paths)})
 
 
 class GsStatusStageAllFilesCommand(TextCommand, GitCommand):

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -1,3 +1,4 @@
+import sublime
 from sublime_plugin import TextCommand
 
 from ...core.git_command import GitCommand
@@ -13,17 +14,60 @@ class GsOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemote
     """
     Open a new browser window to the web-version of the currently opened
     (or specified) file. If `preselect` is `True`, include the selected
-    lines in the request.
+    lines in the request. If the active tracked remote is the same as the
+    integrated remote, open browser directly, if not, display a list to remotes
+    to choose from.
 
     At present, this only supports github.com and GitHub enterprise.
     """
 
-    def run(self, edit, preselect=False, fpath=None):
-        fpath = fpath or self.get_rel_path()
+    def run(self, edit, remote=None, preselect=False, fpath=None):
+        sublime.set_timeout_async(
+            lambda: self.run_async(remote, preselect, fpath))
+
+    def run_async(self, remote, preselect, fpath):
+        self.fpath = fpath or self.get_rel_path()
+        self.preselect = preselect
+
+        self.remotes = self.get_remotes()
+        self.remote_keys = list(self.remotes.keys())
+
+        if not remote:
+            remote = self.guess_github_remote()
+
+        if remote:
+            self.open_file_on_remote(remote)
+        else:
+            try:
+                pre_selected_index = self.remote_keys.index(self.last_remote_used)
+            except ValueError:
+                pre_selected_index = 0
+
+            self.view.window().show_quick_panel(
+                self.remote_keys,
+                self.on_select_remote,
+                flags=sublime.MONOSPACE_FONT,
+                selected_index=pre_selected_index
+            )
+
+    def on_select_remote(self, index):
+        if index < 0:
+            return
+
+        remote = self.remote_keys[index]
+        self.last_remote_used = remote
+        self.open_file_on_remote(remote)
+
+    def open_file_on_remote(self, remote):
+        fpath = self.fpath
+        if isinstance(fpath, str):
+            fpath = [fpath]
+        remote_url = self.remotes[remote]
+        commit_hash = self.get_commit_hash_for_head()
         start_line = None
         end_line = None
 
-        if preselect:
+        if self.preselect and len(fpath) == 1:
             selections = self.view.sel()
             if len(selections) >= 1:
                 first_selection = selections[0]
@@ -32,13 +76,14 @@ class GsOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemote
                 start_line = self.view.rowcol(first_selection.begin())[0] + 1
                 end_line = self.view.rowcol(last_selection.end())[0] + 1
 
-        open_file_in_browser(
-            fpath,
-            self.get_integrated_remote_url(),
-            self.get_commit_hash_for_head(),
-            start_line=start_line,
-            end_line=end_line
-        )
+        for p in fpath:
+            open_file_in_browser(
+                p,
+                remote_url,
+                commit_hash,
+                start_line=start_line,
+                end_line=end_line
+            )
 
 
 class GsOpenGithubRepoCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):
@@ -47,8 +92,37 @@ class GsOpenGithubRepoCommand(TextCommand, GitCommand, git_mixins.GithubRemotesM
     Open a new browser window to the GitHub remote repository.
     """
 
-    def run(self, edit):
-        open_repo(self.get_integrated_remote_url())
+    def run(self, edit, remote=None):
+        sublime.set_timeout_async(lambda: self.run_async(remote))
+
+    def run_async(self, remote):
+        self.remotes = self.get_remotes()
+        self.remote_keys = list(self.remotes.keys())
+
+        if not remote:
+            remote = self.guess_github_remote()
+
+        if remote:
+            open_repo(self.remotes[remote])
+        else:
+            try:
+                pre_selected_index = self.remote_keys.index(self.last_remote_used)
+            except ValueError:
+                pre_selected_index = 0
+
+            self.view.window().show_quick_panel(
+                self.remote_keys,
+                self.on_select_remote,
+                flags=sublime.MONOSPACE_FONT,
+                selected_index=pre_selected_index
+            )
+
+    def on_select_remote(self, index):
+        if index < 0:
+            return
+        remote = self.remote_keys[index]
+        self.last_remote_used = remote
+        open_repo(self.remotes[remote])
 
 
 class GsOpenGithubIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -29,3 +29,20 @@ class GithubRemotesMixin():
         configured_remote_name = self.get_integrated_remote_name()
         remotes = self.get_remotes()
         return remotes[configured_remote_name]
+
+    def guess_github_remote(self):
+        upstream = self.get_upstream_for_active_branch()
+        integrated_remote = self.get_integrated_remote_name()
+        remotes = self.get_remotes()
+
+        if len(self.remotes) == 1:
+            return list(remotes.keys())[0]
+        elif upstream:
+            tracked_remote = upstream.split("/")[0] if upstream else None
+
+            if tracked_remote and tracked_remote == integrated_remote:
+                return tracked_remote
+            else:
+                return None
+        else:
+            return integrated_remote


### PR DESCRIPTION
`github: open file` and `open repo` are now remote sensitive. They will check if the current tracking remote is the same as the integrated remote. If they are the same (or there is only one remote), the browser will be opened directly. Otherwise, the list of remotes will be displayed to choose from.
![untitled](https://cloud.githubusercontent.com/assets/1690993/16962508/e0b43914-4dbf-11e6-9e6f-d3df15d48f00.gif)

depends on #459 
close #335
