### PR TITLE
Fix: refresh status bar after custom git command

### DIFF
--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -73,3 +73,4 @@ class GsCustomCommand(WindowCommand, GitCommand):
 
         if output_to_panel:
             util.log.panel(stdout)
+        util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -72,5 +72,5 @@ class GsCustomCommand(WindowCommand, GitCommand):
         sublime.status_message(complete_msg)
 
         if output_to_panel:
-            util.log.panel(stdout)
+            util.log.panel(stdout.replace("\r", "\n"))
         util.view.refresh_gitsavvy(self.window.active_view())


### PR DESCRIPTION
As title.

Also replace \r by \n in output panel.

<img width="915" alt="screen shot 2016-07-19 at 11 31 09 pm" src="https://cloud.githubusercontent.com/assets/1690993/16974377/f68e5a36-4e09-11e6-91b4-a3c9db4f1106.png">
