### PR TITLE
Enhancement: add github integration config GitSavvy.ghBranch

### DIFF
--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -170,13 +170,22 @@ class GsCreatePullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemot
                     sublime.message_dialog(
                         "Your current branch is different from its remote counterpart. %s" % secondary)
                 else:
-                    base_remote = github.parse_remote(self.get_integrated_remote_url())
                     owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
-                    self.open_comparision_in_browser(base_remote.url, owner, remote_branch.name)
+                    self.open_comparision_in_browser(
+                        owner,
+                        remote_branch.name
+                    )
 
-    def open_comparision_in_browser(self, url, owner, branch):
-        open_in_browser("{}/compare/{}:{}?expand=1".format(
+    def open_comparision_in_browser(self, owner, branch):
+        base_remote = github.parse_remote(self.get_integrated_remote_url())
+        url = base_remote.url
+        base_owner = base_remote.owner
+        base_branch = self.get_integrated_branch_name()
+
+        open_in_browser("{}/compare/{}:{}...{}:{}?expand=1".format(
             url,
+            base_owner,
+            base_branch,
             owner,
             branch
         ))

--- a/github/git_mixins/remotes.py
+++ b/github/git_mixins/remotes.py
@@ -1,5 +1,18 @@
 class GithubRemotesMixin():
 
+    def get_integrated_branch_name(self):
+        configured_branch_name = self.git(
+            "config",
+            "--local",
+            "--get",
+            "GitSavvy.ghBranch",
+            throw_on_stderr=False
+            ).strip()
+        if configured_branch_name:
+            return configured_branch_name
+        else:
+            return "master"
+
     def get_integrated_remote_name(self):
         return self.git(
             "config",


### PR DESCRIPTION
This is needed to produce a correct comparision when the integered
remote is a forked remote.

For example, if the integrated remote is configed as randy3k,
the original code opens
https://github.com/randy3k/GitSavvy/compare/randy3k:comparision?expand=1

However, github redirects it to

https://github.com/divmain/GitSavvy/compare/master...randy3k:comparision?expand=1

To adderss the issue, the new link used is

https://github.com/randy3k/GitSavvy/compare/randy3k:master...randy3k:comparision?expand=1