### PR TITLE
Fix: allow remote tags using gs_tag_delete and gs_tag_view_log

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -507,7 +507,7 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "git-savvy.tags meta.git-savvy.section.tags.local meta.git-savvy.tags.tag" }
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.tags meta.git-savvy.section.tags meta.git-savvy.tags.tag" }
         ]
     },
     {
@@ -516,7 +516,7 @@
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true },
-            { "key": "selector", "operator": "equal", "operand": "git-savvy.tags meta.git-savvy.section.tags.local meta.git-savvy.tags.tag" }
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.tags meta.git-savvy.section.tags meta.git-savvy.tags.tag" }
         ]
     },
     {


### PR DESCRIPTION
df95ea3f7276bb5b50bbdf79f3064ff5b8054a55 did not allow remote tags.