### PR TITLE
Fix: quick stage handles merge conflicts

### DIFF
--- a/core/commands/quick_stage.py
+++ b/core/commands/quick_stage.py
@@ -95,15 +95,29 @@ class GsQuickStageCommand(WindowCommand, GitCommand):
         staged_count = 0
         unstaged_count = 0
 
-        for entry in status_entries:
-            if entry.index_status != "?" and entry.index_status != " ":
-                staged_count += 1
-            if entry.working_status in ("M", "D", "?"):
-                unstaged_count += 1
-                filename = (entry.path if not entry.index_status == "R"
-                            else entry.path + " <- " + entry.path_alt)
-                menu_text = "[{0}] {1}".format(entry.working_status, filename)
-                menu_options.append(MenuOption(True, menu_text, filename, entry.index_status == "?"))
+        (staged_entries,
+         unstaged_entries,
+         untracked_entries,
+         conflict_entries) = self.sort_status_entries(self.get_status())
+
+        staged_count = len(staged_entries)
+        unstaged_count = len(unstaged_entries)
+        # untracked_count = len(untracked_entries)
+        # conflict_count = len(conflict_entries)
+
+        for entry in unstaged_entries:
+            filename = (entry.path if not entry.index_status == "R"
+                        else entry.path + " <- " + entry.path_alt)
+            menu_text = "[{0}] {1}".format(entry.working_status, filename)
+            menu_options.append(MenuOption(True, menu_text, filename, False))
+
+        for entry in untracked_entries:
+            menu_text = "[{0}] {1}".format(entry.working_status, entry.path)
+            menu_options.append(MenuOption(True, menu_text, entry.path, True))
+
+        for entry in conflict_entries:
+            menu_text = "[{0}] {1}".format(entry.working_status, entry.path)
+            menu_options.append(MenuOption(True, menu_text, entry.path, False))
 
         if unstaged_count > 0:
             menu_options.append(MenuOption(True, ADD_ALL_UNSTAGED_FILES, None, None))

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from ..constants import MERGE_CONFLICT_PORCELAIN_STATUSES
 
 FileStatus = namedtuple("FileStatus", ("path", "path_alt", "index_status", "working_status"))
 
@@ -90,3 +91,23 @@ class StatusMixin():
             for raw_entry in stdout.split(":")
             if raw_entry
         ]
+
+    def sort_status_entries(self, file_status_list):
+        """
+        Take entries from `git status` and sort them into groups.
+        """
+        staged, unstaged, untracked, conflicts = [], [], [], []
+
+        for f in file_status_list:
+            if (f.index_status, f.working_status) in MERGE_CONFLICT_PORCELAIN_STATUSES:
+                conflicts.append(f)
+                continue
+            if f.index_status == "?":
+                untracked.append(f)
+                continue
+            elif f.working_status in ("M", "D"):
+                unstaged.append(f)
+            if f.index_status != " ":
+                staged.append(f)
+
+        return staged, unstaged, untracked, conflicts

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -7,7 +7,6 @@ from ..commands import *
 from ...common import ui
 from ..git_command import GitCommand
 from ...common import util
-from ..constants import MERGE_CONFLICT_PORCELAIN_STATUSES
 
 
 class GsShowStatusCommand(WindowCommand, GitCommand):
@@ -124,27 +123,6 @@ class StatusInterface(ui.Interface, GitCommand):
 
     def on_new_dashboard(self):
         self.view.run_command("gs_status_select_first_file")
-
-    @staticmethod
-    def sort_status_entries(file_status_list):
-        """
-        Take entries from `git status` and sort them into groups.
-        """
-        staged, unstaged, untracked, conflicts = [], [], [], []
-
-        for f in file_status_list:
-            if (f.index_status, f.working_status) in MERGE_CONFLICT_PORCELAIN_STATUSES:
-                conflicts.append(f)
-                continue
-            if f.index_status == "?":
-                untracked.append(f)
-                continue
-            elif f.working_status in ("M", "D"):
-                unstaged.append(f)
-            if f.index_status != " ":
-                staged.append(f)
-
-        return staged, unstaged, untracked, conflicts
 
     @ui.partial("branch_status")
     def render_branch_status(self):


### PR DESCRIPTION
move to `sort_status_entries` to mixins and use `sort_status_entries` to fix `quick stage` issues of handling merge conflicts.