### PR TITLE
Enhancedment: use thread.Thread to execute util.file.determine_syntax_files

### DIFF
--- a/git_savvy.py
+++ b/git_savvy.py
@@ -1,13 +1,14 @@
 import sys
-
+import threading
 import sublime
+
 
 if sys.version_info[0] == 2:
     raise ImportWarning("GitSavvy does not support Sublime Text 2.")
 else:
     def plugin_loaded():
         from .common import util
-        sublime.set_timeout_async(util.file.determine_syntax_files)
+        threading.Thread(target=util.file.determine_syntax_files).start()
 
         # Ensure all interfaces are ready.
         sublime.set_timeout_async(


### PR DESCRIPTION

It seems that sublime.set_timeout_async still slow down the start up of
Sublime Text. For instance, the quick panel (e.g., `git: log`) is not ready until a few second
after ST opens. I suspect that they share the same second thread.

Changing `sublime.set_timeout_async` to `threading.Thread` so that the quick panel
(and other UI) does not have to wait for util.file.determine_syntax_files