### PR TITLE
Enhancement: graph syntax shows author/date and highlights merge branches

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -177,8 +177,8 @@
 
         NOTE: Changes you make may break in-view functionality, so use with caution.
      */
-    // "git_graph_args": ["log", "--pretty=format:%h%d (%ar) by `%an` %s", "--graph"],
-    "git_graph_args": ["log", "--oneline", "--graph", "--decorate"],
+    // "git_graph_args": ["log", "--oneline", "--graph", "--decorate"],
+    "git_graph_args": ["log", "--pretty=format:%h%d %s (%ar) <%an>", "--graph"],
 
     /*
         When set to `true`, GitSavvy will prompt for confirmation when closing

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -7,7 +7,7 @@ hidden: true
 scope: git-savvy
 contexts:
   main:
-    - match: '([| \\/_]+)'
+    - match: '([| \\/_.-]+)'
       comment: graph lines
       scope: comment.git-savvy.graph.graph-line
 
@@ -52,7 +52,7 @@ contexts:
       comment: issue numbers
       scope: string.other.issue.git-savvy
 
-    - match: Merge branch (')(.*?)(')\s*(?:(?:of|into)\s+(.*))?
+    - match: Merge branch (')(.*?)(')\s*(?:(?:of|into)\s+(\S*))?
       comment: merges
       scope: meta.git-savvy.grph.merge
       captures:
@@ -61,7 +61,22 @@ contexts:
         3: punctuation.string.end.git-savvy
         4: string.other.merge.remote.git-savvy
 
-    - match: Merge pull request (#\d+) from (.*)
+    - match: Merge branches\b
+      comment: merges
+      scope: meta.git-savvy.grph.merge
+      push:
+        - match: (')(.*?)(')(?:,| and)?
+          captures:
+            1: punctuation.string.begin.git-savvy
+            2: string.other.merge.branch-name.git-savvy
+            3: punctuation.string.end.git-savvy
+        - match: (?:of|into)\s+(\S*)
+          captures:
+            1: string.other.merge.remote.git-savvy
+        - match: (?=\S)
+          pop: true
+
+    - match: Merge pull request (#\d+) from (\S*)
       scope: meta.git-savvy.grph.merge
       captures:
         0: meta.git-savvy.grph.merge.pull-request
@@ -70,5 +85,13 @@ contexts:
 
     - match: ':'
       scope: punctuation.separator.key-value.git-savvy
+
+
+    - match: (\([^)]*?\)) (<[^>]*?>)(?=$)
+      scope: meta.git-savvy.grph.info
+      captures:
+        1: storage.type.time.git-savvy
+        2: entity.name.tag.author.git-savvy
+
     - match: $
       pop: true

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -9,7 +9,7 @@ contexts:
   main:
     - match: '([| \\/_.-]+)'
       comment: graph lines
-      scope: comment.git-savvy.graph.graph-line
+      scope: punctuation.other.git-savvy.graph.graph-line
 
     - match: '[*●]'
       scope: keyword.graph.commit.git-savvy


### PR DESCRIPTION
Fix the highlight of "Merge Branches" and show date and author info.

Before

<img width="760" alt="screen shot 2016-07-30 at 8 09 13 pm" src="https://cloud.githubusercontent.com/assets/1690993/17273842/31dc6efc-5693-11e6-8af8-7502b4aacd31.png">

After

<img width="655" alt="screen shot 2016-07-31 at 1 21 32 am" src="https://cloud.githubusercontent.com/assets/1690993/17274723/2a600948-56bd-11e6-83bf-44224e899a3d.png">


The update is backward compatible to the original default
```
"git_graph_args": ["log", "--oneline", "--graph", "--decorate"]
```

Also, it changes the scope of the graph lines from comment to punctuation. As comments are italic for most color schemes and italic lines do not align.