### PR TITLE
Enhancement: rename `git: graph current branch` to `git: graph`

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -55,7 +55,7 @@
         "args": { "amend": true }
     },
     {
-        "caption": "git: graph current branch",
+        "caption": "git: graph",
         "command": "gs_log_graph"
     },
     {


### PR DESCRIPTION
There are two reasons for such a rename.

1. `git: graph` is now consistent with `git: log` to show commits of the current branch.

2. typing `git: gr..` in command palette always select `git: graph all branches` first. However `git: graph current branch` is far more frequently used (at least for myself). Renaming it to `git: graph` makes it appear before `git: graph all branches`.