### PR TITLE
Fix: allow renamed/copied status to correctly render

### DIFF
--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -21,8 +21,8 @@ class StatusMixin():
     def get_status(self):
         """
         Return a list of FileStatus objects.  These objects correspond
-        to all files that are 1) staged, 2) modified, 3) new, or 4)
-        deleted, as well as additional status information that can
+        to all files that are 1) staged, 2) modified, 3) new, 4) deleted,
+        5) renamed, or 6) copied as well as additional status information that can
         occur mid-merge.
         """
         stdout = self.git("status", "--porcelain", "-z")
@@ -36,7 +36,7 @@ class StatusMixin():
             index_status = entry[0]
             working_status = entry[1].strip() or None
             path = entry[3:]
-            path_alt = porcelain_entries.__next__() if index_status == "R" else None
+            path_alt = porcelain_entries.__next__() if index_status in ["R", "C"] else None
             entries.append(FileStatus(path, path_alt, index_status, working_status))
 
         return entries

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -140,8 +140,15 @@ class StatusInterface(ui.Interface, GitCommand):
     def render_staged_files(self):
         if not self.staged_entries:
             return ""
+
+        def get_path(file_status):
+            """ Display full file_status path, including path_alt if exists """
+            if file_status.path_alt:
+                return '{} -> {}'.format(file_status.path_alt, file_status.path)
+            return file_status.path
+
         return self.template_staged.format("\n".join(
-            "  {} {}".format("-" if f.index_status == "D" else " ", f.path)
+            "  {} {}".format("-" if f.index_status == "D" else " ", get_path(f))
             for f in self.staged_entries
             ))
 


### PR DESCRIPTION
- both files will now be displayed according to the rename/copy direction:
  old file -> new file

More info: https://git-scm.com/docs/git-status

Close #339