### PR TITLE
[FIX] limit graph to 20k commits

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -178,7 +178,7 @@
         NOTE: Changes you make may break in-view functionality, so use with caution.
      */
     // "git_graph_args": ["log", "--oneline", "--graph", "--decorate"],
-    "git_graph_args": ["log", "--pretty=format:%h%d %s (%ar) <%an>", "--graph"],
+    "git_graph_args": ["log", "--pretty=format:%h%d %s (%ar) <%an>", "--graph", "--max-count=20000"],
 
     /*
         When set to `true`, GitSavvy will prompt for confirmation when closing

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -178,7 +178,7 @@
         NOTE: Changes you make may break in-view functionality, so use with caution.
      */
     // "git_graph_args": ["log", "--oneline", "--graph", "--decorate"],
-    "git_graph_args": ["log", "--pretty=format:%h%d %s (%ar) <%an>", "--graph", "--max-count=20000"],
+    "git_graph_args": ["log", "--pretty=format:%h%d %s (%ar) <%an>", "--graph", "--max-count=10000"],
 
     /*
         When set to `true`, GitSavvy will prompt for confirmation when closing


### PR DESCRIPTION
From then on, risks are it becomes slow on huge repos. You still can adapt the setting, if need be.

Fix #494 