### PR TITLE
Better exceptions

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -11,7 +11,8 @@ import sublime
 from sublime_plugin import WindowCommand, TextCommand, EventListener
 
 from .navigate import GsNavigate
-from ..git_command import GitCommand, GitSavvyError
+from ..git_command import GitCommand
+from ..exceptions import GitSavvyError
 from ...common import util
 
 

--- a/core/commands/git_add.py
+++ b/core/commands/git_add.py
@@ -6,10 +6,11 @@ import os
 import sys
 
 import sublime
-from sublime_plugin import WindowCommand, TextCommand, EventListener
+from sublime_plugin import WindowCommand, TextCommand
 
-from ..git_command import GitCommand, GitSavvyError
 from ...common import util
+from ..git_command import GitCommand
+from ..exceptions import GitSavvyError
 
 
 TITLE = "GIT-ADD: {}"

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -11,3 +11,7 @@ class GitSavvyError(Exception):
             if kwargs.get('show_status', False):
                 sublime.status_message(msg)
             util.debug.log_error(msg)
+
+
+class FailedGithubRequest(GitSavvyError):
+    pass

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -1,0 +1,13 @@
+import sublime
+from ..common import util
+
+
+class GitSavvyError(Exception):
+    def __init__(self, msg, *args, **kwargs):
+        super(GitSavvyError, self).__init__(msg, *args, **kwargs)
+        if msg:
+            if kwargs.get('show_panel', True):
+                util.log.panel(msg)
+            if kwargs.get('show_status', False):
+                sublime.status_message(msg)
+            util.debug.log_error(msg)

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -25,6 +25,7 @@ from .git_mixins.tags import TagsMixin
 from .git_mixins.history import HistoryMixin
 from .git_mixins.rewrite import RewriteMixin
 from .git_mixins.merge import MergeMixin
+from .exceptions import GitSavvyError
 
 
 git_path = None
@@ -41,10 +42,6 @@ FALLBACK_PARSE_ERROR_MSG = (
     "if you have checked binary data into your repository.  The current "
     "operation has been aborted."
 )
-
-
-class GitSavvyError(Exception):
-    pass
 
 
 class GitCommand(StatusMixin,
@@ -114,8 +111,6 @@ class GitCommand(StatusMixin,
             sublime.status_message(
                 "Failed to run `git {}`. See log for details.".format(command[1])
             )
-            util.log.panel(msg)
-            util.debug.log_error(msg)
             raise GitSavvyError(msg)
 
         try:

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -31,16 +31,20 @@ class GsPullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixi
     """
 
     def run(self, edit):
+        sublime.status_message("Getting pull requests...")
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
         base_remote = github.parse_remote(self.get_integrated_remote_url())
         self.pull_requests = github.get_pull_requests(base_remote)
-
-        self.view.window().show_quick_panel(
-            [create_palette_entry(pr) for pr in self.pull_requests],
-            self.on_select_pr
-            )
+        if not self.pull_requests:
+            sublime.status_message("No pull requests found.")
+        else:
+            sublime.status_message("Found %i pull requests" % len(self.pull_requests))
+            self.view.window().show_quick_panel(
+                [create_palette_entry(pr) for pr in self.pull_requests],
+                self.on_select_pr
+                )
 
     def on_select_pr(self, idx):
         if idx == -1:

--- a/github/github.py
+++ b/github/github.py
@@ -10,12 +10,9 @@ from functools import partial
 import sublime
 
 from ..common import interwebs
+from ..core.exceptions import FailedGithubRequest
 
 GitHubRepo = namedtuple("GitHubRepo", ("url", "fqdn", "owner", "repo", "token"))
-
-
-class FailedGithubRequest(Exception):
-    pass
 
 
 def parse_remote(remote):
@@ -116,7 +113,7 @@ def query_github(api_url_template, github_repo):
 
     response = interwebs.get(fqdn, 443, path, https=True, auth=auth)
     if response.status < 200 or response.status > 299 or not response.is_json:
-        raise FailedGithubRequest(response.payload)
+        raise FailedGithubRequest('Error querying github: %s' % response.payload)
 
     return response.payload
 


### PR DESCRIPTION
* Import GitSavvyError to always log the thrown error

  - move GitSavvyError to exception module
  - refactor modules to correct import location

* Add status updates when fetching pulling requests
  - This shows users what's going on, and when fetching finished whether any pull requests were found or not.
  - Moving FailedGithubRequest to exceptions and inherit from GitSavvyError will keep
the exception logic seperate, while also logging the errors more visibly
