### PR TITLE
Feature: better selection of base ref branch

### DIFF
--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -1,5 +1,6 @@
 import difflib
 import re
+import time
 
 from ..exceptions import GitSavvyError
 from ...common import util
@@ -77,6 +78,7 @@ class NearestBranchMixin(object):
         http://stackoverflow.com/a/17843908/484127
         http://stackoverflow.com/questions/1527234
         """
+        start = time.time()
         try:
             relatives = self.branch_relatives(branch)
         except GitSavvyError:
@@ -90,13 +92,19 @@ class NearestBranchMixin(object):
                               len(relatives), relatives))
 
         nearest = self._nearest_from_relatives(relatives, branch)
+
+        end = time.time()
+        util.debug.add_to_log('nearest_branch: Located nearest branch in {:.4f}'
+                              ' seconds'.format(end - start))
+
         if not nearest:
             util.debug.add_to_log('nearest_branch: No valid nearest found. '
                                   'Possibly on a root / detached branch!')
             return default
 
-        util.debug.add_to_log('nearest_branch: Found best candidate {}'.format(nearest))
         # if same as branch, return default instead
         if branch == nearest:
+            util.debug.add_to_log('nearest_branch: Best candidate is source branch; using default')
             return default
+        util.debug.add_to_log('nearest_branch: Found best candidate {}'.format(nearest))
         return nearest

--- a/core/git_mixins/rebase.py
+++ b/core/git_mixins/rebase.py
@@ -1,0 +1,102 @@
+import difflib
+import re
+
+from ..exceptions import GitSavvyError
+from ...common import util
+
+NEAREST_NODE_PATTERN = re.compile(r'.*\*.*\[(.*?)(?:(?:[\^\~]+[\d]*){1})\]')  # http://regexr.com/3gm03
+
+
+class NearestBranchMixin(object):
+    """ Provide reusable methods for detecting the nearest of a branch relatives """
+
+    def branch_relatives(self, branch):
+        """ Geta  list of all relatives from ``git show-branch`` results """
+        branch_tree = self.git("show-branch", "--no-color").splitlines()
+        util.debug.add_to_log('nearest_branch: found {} show-branch results'.format(
+                              len(branch_tree)))
+        relatives = []
+        for rel in branch_tree:
+            match = re.search(NEAREST_NODE_PATTERN, rel)
+            if not match:
+                continue
+            branch_name = match.groups()[0]
+            if branch_name != branch and branch_name not in relatives:
+                relatives.append(branch_name)
+        return relatives
+
+    def _nearest_from_relatives(self, relatives, branch):
+        """
+        Find the nearest branch from the "branch-out nodes" of all relatives.
+        """
+        util.debug.add_to_log('nearest_branch: filtering branches that share branch-out nodes')
+        diff = difflib.Differ()
+        branch_commits = self.git("rev-list", "--first-parent", branch).splitlines()
+        max_revisions = 100
+        for relative in relatives:
+            util.debug.add_to_log('nearest_branch: Getting common commits with {}'.format(relative))
+            relative_commits = self.git("rev-list", "-{}".format(max_revisions),
+                                        "--first-parent", relative).splitlines()
+
+            # Enumerate over branch vs relative commit hashes and look for a common one
+            common = None
+            for line in diff.compare(branch_commits, relative_commits):
+                if not line.startswith(' '):
+                    util.debug.add_to_log('nearest_branch: commit differs {}'.format(line))
+                    continue
+                common = line.strip()
+                util.debug.add_to_log('nearest_branch: found common commit {}'.format(common))
+                break
+
+            if not common:
+                util.debug.add_to_log('nearest_branch: No common commit found with {}'.format(relative))
+                continue
+
+            # Found common "branch-out node", get reachable branches for commit
+            branches = self.git("branch", "--contains", common, "--merged").splitlines()
+            cleaned_branch_names = [b[2:].strip() for b in branches]
+            util.debug.add_to_log('nearest_branch: got valid branches {}'.format(cleaned_branch_names))
+            if relative in cleaned_branch_names:
+                return relative
+
+        return None
+
+    def nearest_branch(self, branch, default="master"):
+        """
+        Find the nearest commit in current branch history that exists
+        on a different branch and return that branch name.
+
+        We filter these branches through a list of known ancestors which have
+        an initial branch point with current branch, and pick the first one
+        that matches both.
+
+        If no such branch is found, returns the given default ("master" if not
+        specified).
+
+        Solution snagged from:
+        http://stackoverflow.com/a/17843908/484127
+        http://stackoverflow.com/questions/1527234
+        """
+        try:
+            relatives = self.branch_relatives(branch)
+        except GitSavvyError:
+            return default
+
+        if not relatives:
+            util.debug.add_to_log('nearest_branch: No relatives found. '
+                                  'Possibly on a root branch!')
+            return default
+        util.debug.add_to_log('nearest_branch: found {} relatives: {}'.format(
+                              len(relatives), relatives))
+
+        nearest = self._nearest_from_relatives(relatives, branch)
+        if not nearest:
+            util.debug.add_to_log('nearest_branch: No valid nearest found. '
+                                  'Possibly on a root / detached branch!')
+            return default
+
+        util.debug.add_to_log('nearest_branch: Found best candidate {}'.format(nearest))
+        # if same as branch, return default instead
+        if branch == nearest:
+            return default
+        return nearest

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -930,6 +930,10 @@ class GsRebaseDefineBaseRefCommand(PanelActionMixin, TextCommand, GitCommand):
         ["select_ref", "Use ref as base."],
     ]
 
+    def run(self, *args):
+        self.interface = ui.get_interface(self.view.id())
+        super().run(*args)
+
     def _get_branches(self):
         branches = [branch.name_with_remote
                     for branch in self.get_branches()
@@ -940,9 +944,11 @@ class GsRebaseDefineBaseRefCommand(PanelActionMixin, TextCommand, GitCommand):
         if branches is None:
             sublime.set_timeout_async(self._get_branches, 0)
         else:
+            base_ref = self.interface.base_ref()
             self.view.window().show_quick_panel(
                 branches,
-                filter_quick_panel(lambda idx: self.set_base_ref(branches[idx]))
+                filter_quick_panel(lambda idx: self.set_base_ref(branches[idx])),
+                selected_index=branches.index(base_ref) if base_ref in branches else None
             )
 
     def select_ref(self):

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -312,7 +312,7 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
 
             if not base_ref:
                 # use remote tracking branch as a sane default
-                remote_branch = self.get_active_remote_branch().name_with_remote
+                remote_branch = self.get_upstream_for_active_branch()
                 base_ref = self.nearest_branch(self.get_current_branch_name(),
                                                default=remote_branch or "master")
                 util.debug.add_to_log('Found base ref {}'.format(base_ref))

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -17,6 +17,7 @@ from ..ui_mixins.quick_panel import show_log_panel
 COMMIT_NODE_CHAR = "●"
 COMMIT_NODE_CHAR_OPTIONS = "●*"
 COMMIT_LINE = re.compile("\s*[%s]\s*([a-z0-9]{3,})" % COMMIT_NODE_CHAR_OPTIONS)
+NEAREST_NODE_PATTERN = re.compile(r'.*\*.*\[(.*?)(?:(?:[\^\~]+[\d]*){1})\]')  # http://regexr.com/3gm03
 
 
 def filter_quick_panel(fn):
@@ -121,7 +122,6 @@ class RebaseInterface(ui.Interface, GitCommand):
 
     _base_commit = None
     _active_conflicts = None
-    nearest_node_pattern = r'.*\*.*\[(.*?)(?:(?:[\^\~]+[\d]*)*)\]'  # http://regexr.com/3ehtn
 
     def __init__(self, *args, **kwargs):
         self.conflicts_keybindings = \
@@ -363,8 +363,7 @@ class RebaseInterface(ui.Interface, GitCommand):
 
         relatives = []
         for rel in branch_tree:
-            match = re.search(self.nearest_node_pattern, rel)
-            # print(match.groups(), branch, default)
+            match = re.search(NEAREST_NODE_PATTERN, rel)
             if not match:
                 continue
             branch_name = match.groups()[0]

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -78,11 +78,17 @@ This will display the selected commit data and meta-data in a new window, includ
 
 ### Rebasing
 
+#### Initial base tip detection
+
+When opening the rebase dashboard, GitSavvy will attempt to automatically deteremine the base-ref to use. First it will lookup the root commit of the current branch, i.e. the HEAD when you typed `git checkout -b BRANCH_NAME`.
+
+Failing to find the nearest base ref branch, GitSavvy will use the tracked branch if configured, else fallback to `master`.
+
+The resulting branch is then used as the starting point for the displayed information.
+
 #### Define base ref for the dashboard (`f`)
 
-When initially opening the rebase dashboard, GitSavvy will attempt to determine the root commit of the branch, i.e. the HEAD when you typed `git checkout -b BRANCH_NAME`.  This commit is used as the starting point for the information that is displayed.
-
-In most cases, this will default to `master`.  However, if you would like to compare the current branch against something other than local `master`, using this command will allow you to make that selection. You can override the default per-project by adding a `rebase_default_base_ref` to your `.sublime-project` file:
+If you want to compare the current branch against something other than the initially detected branch, using this command will allow you to make that selection. You can override the default, per-project, by adding a `rebase_default_base_ref` to your `.sublime-project` file:
 
 ```json
 {


### PR DESCRIPTION
Before, we used a base ref that was specified in settings, otherwise defaulting to hardcoded "master".

Now, we find the nearest common ancestor branch and use that as our default base, still allowing override in settings.

Fixes #499
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

