### PR TITLE
Fix: Avoid exception when window is None

### DIFF
--- a/common/util/view.py
+++ b/common/util/view.py
@@ -69,7 +69,8 @@ def refresh_gitsavvy(view):
         view.run_command("gs_branches_diff_commit_history_refresh")
 
     view.run_command("gs_update_status_bar")
-    view.window().run_command("refresh_folder_list")
+    if view.window():
+        view.window().run_command("refresh_folder_list")
 
 
 def handle_closed_view(view):


### PR DESCRIPTION
Some open files (maybe without project), would otherwise occasionally raise the following exception in console:

```python
  File "/Users/pavel/Library/Application Support/Sublime Text 3/Packages/GitSavvy/common/util/view.py", line 72, in refresh_gitsavvy
    view.window().run_command("refresh_folder_list")
AttributeError: 'NoneType' object has no attribute 'run_command'
```