### PR TITLE
Feature: use arrow key to navigate on dashboards

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -381,6 +381,26 @@
         ]
     },
     {
+        "keys": ["down"],
+        "command": "gs_status_navigate_file",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "gs_status_navigate_file",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["j"],
         "command": "gs_status_navigate_file",
         "args": { "forward": true },
@@ -477,7 +497,7 @@
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
         ]
     },
-        {
+    {
         "keys": ["j"],
         "command": "gs_diff_navigate",
         "args": { "forward": true },
@@ -728,6 +748,26 @@
         ]
     },
     {
+        "keys": ["down"],
+        "command": "gs_tags_navigate_tag",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "gs_tags_navigate_tag",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.tags_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["j"],
         "command": "gs_tags_navigate_tag",
         "args": { "forward": true },
@@ -952,6 +992,26 @@
         ]
     },
     {
+        "keys": ["down"],
+        "command": "gs_branches_navigate_branch",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "gs_branches_navigate_branch",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.branch_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["j"],
         "command": "gs_branches_navigate_branch",
         "args": { "forward": true },
@@ -1029,6 +1089,26 @@
         ]
     },
     {
+        "keys": ["down"],
+        "command": "gs_log_graph_navigate",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "gs_log_graph_navigate",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.log_graph_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["j"],
         "command": "gs_log_graph_navigate",
         "args": {"forward": true},
@@ -1091,6 +1171,24 @@
         "command": "gs_log_graph_navigate",
         "args": { "forward": false },
         "context": [
+            { "key": "setting.git_savvy.compare_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["down"],
+        "command": "gs_log_graph_navigate",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.compare_commit_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "gs_log_graph_navigate",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.compare_commit_view", "operator": "equal", "operand": true }
         ]
     },
@@ -1343,6 +1441,26 @@
         "args": { "forward": false },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["down"],
+        "command": "gs_rebase_navigate_commits",
+        "args": { "forward": true },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
+        "keys": ["up"],
+        "command": "gs_rebase_navigate_commits",
+        "args": { "forward": false },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.arrow_keys_navigation", "operator": "equal", "operand": true },
             { "key": "setting.git_savvy.rebase_view", "operator": "equal", "operand": true }
         ]
     },

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -272,6 +272,11 @@
     "enable_branch_descriptions": true,
 
     /*
+        When set to `true`, you can navigate the dashboards by using arrow keys.
+     */
+    "arrow_keys_navigation": false,
+
+    /*
         When set to `true`, GitSavvy will become Vintagoues friendly.
         You might need to restart Sublime in order to get this working.
      */

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -69,3 +69,16 @@ class GsHandleVintageousCommand(TextCommand):
             self.view.settings().set("git_savvy.vintageous_friendly", True)
             if savvy_settings.get("vintageous_enter_insert_mode", False) is True:
                 self.view.run_command("_enter_insert_mode")
+
+
+class GsHandleArrowKeysCommand(TextCommand):
+
+    """
+    Set the arrow_keys_navigation view setting if needed.
+    It allows navigation by using arrow keys.
+    """
+
+    def run(self, edit):
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        if savvy_settings.get("arrow_keys_navigation", False) is True:
+            self.view.settings().set("git_savvy.arrow_keys_navigation", True)

--- a/common/ui.py
+++ b/common/ui.py
@@ -234,6 +234,7 @@ class GsNewContentAndRegionsCommand(TextCommand):
 
         if self.view.settings().get("git_savvy.interface"):
             self.view.run_command("gs_handle_vintageous")
+            self.view.run_command("gs_handle_arrow_keys")
 
 
 class GsUpdateRegionCommand(TextCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -67,6 +67,7 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
         self.view.run_command("gs_log_graph_more_info")
 
         self.view.run_command("gs_handle_vintageous")
+        self.view.run_command("gs_handle_arrow_keys")
 
 
 class GsLogGraphCurrentBranch(GsLogGraphBase):


### PR DESCRIPTION
Arrow key navigation is enabled on dashboards allowing users to use arrow keys to navigate between branches, files, commits etc.

However, it is not enabled in `diff_view`, `inline_diff_view` and `show_commit_view` . These views are showing commits, may be still useful to have arrow keys.
