### PR TITLE
Enhancement: always show at center when navigating

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -245,7 +245,6 @@ class GsLogGraphNavigateCommand(GsNavigate):
 
     def run(self, edit, **kwargs):
         super().run(edit, **kwargs)
-        self.view.run_command("show_at_center")
         self.view.window().run_command("gs_log_graph_more_info")
 
     def get_available_regions(self):

--- a/core/commands/navigate.py
+++ b/core/commands/navigate.py
@@ -30,6 +30,7 @@ class GsNavigate(TextCommand, GitCommand):
         # Position the cursor at the beginning of the file name.
         new_position += self.offset
         sel.add(sublime.Region(new_position, new_position))
+        self.view.run_command("show_at_center")
 
     def forward(self, current_position, file_regions):
         for file_region in file_regions:


### PR DESCRIPTION
Always move the cursor to center when using the navigating keys. The duplicated code in `GsLogGraphNavigateCommand` is also removed.