### PR TITLE
Feature: refactor quick panel for (mostly) static options

### DIFF
--- a/core/commands/changelog.py
+++ b/core/commands/changelog.py
@@ -29,7 +29,7 @@ class GsGenerateChangeLogCommand(WindowCommand, GitCommand):
 
     def run_async(self):
         view = self.window.show_input_panel(
-            REF_PROMPT, self.get_lastest_local_tag(), self.on_done, None, None)
+            REF_PROMPT, self.get_last_local_tag(), self.on_done, None, None)
         view.run_command("select_all")
 
     def on_done(self, ref):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -2,7 +2,7 @@ import sublime
 from sublime_plugin import WindowCommand, TextCommand
 import re
 from ..git_command import GitCommand
-from .log import GsLogActionCommand
+from .log import GsLogActionCommand, GsLogCommand
 from .navigate import GsNavigate
 from ...common import util
 
@@ -152,33 +152,13 @@ class GsLogGraphByBranchCommand(GsLogGraphBase):
         return args
 
 
-class GsLogGraphCommand(WindowCommand, GitCommand):
-    def run(self, file_path=None, current_file=False):
-        self._file_path = self.file_path if current_file else file_path
-        options_array = [
-            "For current branch",
-            "For all branches",
-            "Filtered by author",
-            "Filtered by branch",
-        ]
-        self.window.show_quick_panel(
-            options_array,
-            self.on_option_selection,
-            flags=sublime.MONOSPACE_FONT
-        )
-
-    def on_option_selection(self, index):
-        if index == -1:
-            return
-
-        if index == 0:
-            self.window.run_command("gs_log_graph_current_branch", {"file_path": self._file_path})
-        elif index == 1:
-            self.window.run_command("gs_log_graph_current_branch", {"file_path": self._file_path})
-        elif index == 2:
-            self.window.run_command("gs_log_graph_by_author", {"file_path": self._file_path})
-        elif index == 3:
-            self.window.run_command("gs_log_graph_by_branch", {"file_path": self._file_path})
+class GsLogGraphCommand(GsLogCommand):
+    default_actions = [
+        ["gs_log_graph_current_branch", "For current branch"],
+        ["gs_log_graph_all_branches", "For all branches"],
+        ["gs_log_graph_by_author", "Filtered by author"],
+        ["gs_log_graph_by_branch", "Filtered by branch"],
+    ]
 
 
 class GsLogGraphActionCommand(GsLogActionCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -185,9 +185,6 @@ class GsLogGraphActionCommand(GsLogActionCommand):
                 ["diff_commit_cache", "Diff commit (cached)"],
             ])
 
-        if self._file_path:
-            self.actions.insert(1, ["show_file_at_commit", "Show file at commit"])
-
     def run(self):
         view = self.window.active_view()
 
@@ -204,7 +201,7 @@ class GsLogGraphActionCommand(GsLogActionCommand):
             sublime.status_message("You can only do actions on one commit at a time.")
             return
 
-        super().run(self._commit_hash)
+        super().run(commit_hash=self._commit_hash, file_path=self._file_path)
 
     def cherry_pick(self):
         self.git("cherry-pick", self._commit_hash)

--- a/core/commands/reset.py
+++ b/core/commands/reset.py
@@ -3,7 +3,7 @@ from sublime_plugin import WindowCommand
 from ..git_command import GitCommand
 from .log import GsLogBase
 from ...common import util
-from ...common.quick_panel import show_paginated_panel
+from ..ui_mixins.quick_panel import show_paginated_panel
 
 
 PADDING = "                                                "

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -63,7 +63,6 @@ class GitCommand(StatusMixin,
     """
 
     _last_remotes_used = {}
-    _quick_panel_compare_against_idx = 0
 
     def git(self, *args,
             stdin=None,
@@ -321,12 +320,3 @@ class GitCommand(StatusMixin,
         class attribute dict.
         """
         self._last_remotes_used[self.repo_path] = value
-
-    @property
-    def quick_panel_compare_against_idx(self):
-        """ Index for quick panel log options"""
-        return self._quick_panel_compare_against_idx
-
-    @quick_panel_compare_against_idx.setter
-    def quick_panel_compare_against_idx(self, value):
-        self._quick_panel_compare_against_idx = value

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -63,7 +63,6 @@ class GitCommand(StatusMixin,
     """
 
     _last_remotes_used = {}
-    _quick_panel_blame_idx = 0
     _quick_panel_compare_against_idx = 0
 
     def git(self, *args,
@@ -322,15 +321,6 @@ class GitCommand(StatusMixin,
         class attribute dict.
         """
         self._last_remotes_used[self.repo_path] = value
-
-    @property
-    def quick_panel_blame_idx(self):
-        """ Index for quick panel blame options"""
-        return self._quick_panel_blame_idx
-
-    @quick_panel_blame_idx.setter
-    def quick_panel_blame_idx(self, value):
-        self._quick_panel_blame_idx = value
 
     @property
     def quick_panel_compare_against_idx(self):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -64,8 +64,6 @@ class GitCommand(StatusMixin,
 
     _last_remotes_used = {}
     _quick_panel_blame_idx = 0
-    _quick_panel_log_idx = 0
-    _quick_panel_log_graph_idx = 0
     _quick_panel_compare_against_idx = 0
 
     def git(self, *args,
@@ -333,24 +331,6 @@ class GitCommand(StatusMixin,
     @quick_panel_blame_idx.setter
     def quick_panel_blame_idx(self, value):
         self._quick_panel_blame_idx = value
-
-    @property
-    def quick_panel_log_idx(self):
-        """ Index for quick panel log options"""
-        return self._quick_panel_log_idx
-
-    @quick_panel_log_idx.setter
-    def quick_panel_log_idx(self, value):
-        self._quick_panel_log_idx = value
-
-    @property
-    def quick_panel_log_graph_idx(self):
-        """ Index for quick panel branch diff commit history options"""
-        return self._quick_panel_log_graph_idx
-
-    @quick_panel_log_graph_idx.setter
-    def quick_panel_log_graph_idx(self, value):
-        self._quick_panel_log_graph_idx = value
 
     @property
     def quick_panel_compare_against_idx(self):

--- a/core/git_mixins/tags.py
+++ b/core/git_mixins/tags.py
@@ -29,9 +29,9 @@ class TagsMixin():
 
         return entries
 
-    def get_lastest_local_tag(self):
+    def get_last_local_tag(self):
         """
-        Return the latest tag of the current branch. get_tags() fails to return an ordered list.
+        Return the last tag of the current branch. get_tags() fails to return an ordered list.
         """
 
         tag = self.git("describe", "--tags", "--abbrev=0", throw_on_stderr=False).strip()

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -834,7 +834,7 @@ class GsRebaseDefineBaseRefCommand(PanelActionMixin, TextCommand, GitCommand):
 
     def select_ref(self):
         self.view.window().show_input_panel(
-            "Enter ref to use for base:",
+            "Enter commit or other ref to use for rebase:",
             "",
             lambda entry: self.set_base_ref(entry) if entry else None,
             None, None
@@ -845,39 +845,12 @@ class GsRebaseDefineBaseRefCommand(PanelActionMixin, TextCommand, GitCommand):
         util.view.refresh_gitsavvy(self.view)
 
 
-class GsRebaseOnTopOfCommand(TextCommand, GitCommand):
+class GsRebaseOnTopOfCommand(GsRebaseDefineBaseRefCommand):
 
-    base_types = [
-        "Rebase on top of branch.",
-        "Rebase on top of ref."
+    default_actions = [
+        ["select_branch", "Rebase on top of branch."],
+        ["select_ref", "Rebase on top of ref."],
     ]
-
-    def run(self, edit):
-        sublime.set_timeout_async(self.run_async, 0)
-
-    def run_async(self):
-        self.view.window().show_quick_panel(
-            self.base_types,
-            filter_quick_panel(self.on_type_select)
-        )
-
-    def on_type_select(self, type_idx):
-        if type_idx == 0:
-            entries = [branch.name_with_remote
-                       for branch in self.get_branches()
-                       if not branch.active]
-            self.view.window().show_quick_panel(
-                entries,
-                filter_quick_panel(lambda idx: self.set_base_ref(entries[idx]))
-            )
-        elif type_idx == 1:
-            self.view.window().show_input_panel(
-                "Enter commit or other ref to use for rebase:",
-                "",
-                lambda entry: self.set_base_ref(entry) if entry else None,
-                None,
-                None
-            )
 
     def set_base_ref(self, selection):
         interface = ui.get_interface(self.view.id())

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -7,6 +7,16 @@ class PanelActionMixin(object):
     """
     Use this mixin to display quick panel, select from pre-defined actions and
     execute the matching class method.
+
+    The `default_actions` are copied into self.actions and should be a list of
+    list/tuple items of at least length of 2, e.g:
+
+    default_actions = [
+        ['some_method', 'Run some method'],
+        ['other_method', 'Run some other method'],
+        ['some_method', 'Run method with arg1 and arg2', ('arg1', 'arg2')],
+        ['some_method', 'Run method with kwargs1: foo', (), {'kwarg1': 'foo'}],
+    ]
     """
     selected_index = 0  # Every instantiated class get their own `selected_index`
     default_actions = None  # must be set by inheriting class
@@ -31,8 +41,20 @@ class PanelActionMixin(object):
             return
 
         self.selected_index = index  # set last selected choice as default
-        action = self.actions[index][0]
-        getattr(self, action)()
+        selected_action = self.actions[index]
+        func = self.get_callable(selected_action)
+        args, kwargs = self.get_arguments(selected_action)
+        func(*args, **kwargs)
+
+    def get_callable(self, selected_action):
+        return getattr(self, selected_action[0])
+
+    def get_arguments(self, selected_action):
+        if len(selected_action) == 3:
+            return selected_action[2], {}
+        elif len(selected_action) == 4:
+            return selected_action[2:4]
+        return (), {}
 
 
 def show_paginated_panel(items, on_done, flags=None, selected_index=None, on_highlight=None,

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -1,6 +1,38 @@
 import itertools
 import sublime
-from . import util
+from ...common import util
+
+
+class PanelActionMixin(object):
+    """
+    Use this mixin to display quick panel, select from pre-defined actions and
+    execute the matching class method.
+    """
+    selected_index = 0  # Every instantiated class get their own `selected_index`
+    default_actions = None  # must be set by inheriting class
+
+    def run(self, *args, **kwargs):
+        self.update_actions()
+        self.show_panel()
+
+    def update_actions(self):
+        self.actions = self.default_actions[:]  # copy default actions
+
+    def show_panel(self, actions=None):
+        self.window.show_quick_panel(
+            [a[1] for a in actions or self.actions],
+            self.on_action_selection,
+            flags=sublime.MONOSPACE_FONT,
+            selected_index=self.selected_index,
+        )
+
+    def on_action_selection(self, index):
+        if index == -1:
+            return
+
+        self.selected_index = index  # set last selected choice as default
+        action = self.actions[index][0]
+        getattr(self, action)()
 
 
 def show_paginated_panel(items, on_done, flags=None, selected_index=None, on_highlight=None,


### PR DESCRIPTION
This  PR adds two reusable mixins that replace much repetitive and sometimes inconsistent code. 
Hopefully this way the commands has less cruft and easier to read.

In  this refactor I only touched panels with "static options". The next step would be to replace the remaining panels that prompt for branch/remote. By default most of the updated commands run in a synchronous manner (in the current thread), since the panel options are available immediately.