### PR TITLE
Fix: various fixes for the push commands

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -277,7 +277,7 @@
         ]
     },
     {
-        "keys": ["P"],
+        "keys": ["p"],
         "command": "gs_push",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -140,9 +140,10 @@ class GsPushToBranchCommand(WindowCommand, PushBase):
         # If the user pressed `esc` or otherwise cancelled.
         if branch_index == -1:
             return
-
+        current_local_branch = self.get_current_branch_name()
         selected_branch = self.branches_on_selected_remote[branch_index].split("/", 1)[1]
-        sublime.set_timeout_async(lambda: self.do_push(self.selected_remote, selected_branch))
+        sublime.set_timeout_async(
+            lambda: self.do_push(self.selected_remote, selected_branch, local_branch=current_local_branch))
 
 
 class GsPushToBranchNameCommand(WindowCommand, PushBase):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -68,7 +68,7 @@ class StatusInterface(ui.Interface, GitCommand):
       [c] commit                            [t][a] apply stash
       [C] commit, including unstaged        [t][p] pop stash
       [m] amend previous commit             [t][s] show stash
-      [P] push current branch               [t][c] create stash
+      [p] push current branch               [t][c] create stash
                                             [t][u] create stash including untracked files
       [i] ignore file                       [t][d] discard stash
       [I] ignore pattern

--- a/docs/remotes.md
+++ b/docs/remotes.md
@@ -18,7 +18,7 @@ When running this command, you will be prompted first for the remote you want to
 
 ## `git: push`
 
-This command performs a simple `git push`.  In recent Git versions, this will result in a push to the tracking branch if it exists, else a remote branch with the same name as the local.
+This command will push current branch to the tracking branch. If the tracking branch is not set, you will be asked to configure it unless `prompt_for_tracking_branch` is set to `false`. In that case, you will be prompted for a remote, then the current branch will be pushed to a remote branch with the same name.
 
 ## `git: push to branch`
 


### PR DESCRIPTION
- `GsPushCommand` only push current branch, fix #566 
- change the keybind from [P] to [p] in Status dashboard so that it is consistent with the branch dashboard.
- extend `GsPushToBranchNameCommand` default arguments to accept a prespecified branch name.
- push current branch to a remote branch with the same name if `prompt_for_tracking_branch` is false
- fix `GsPushToBranchCommand` when the name of the remote branch is not the same as the local