### PR TITLE
Enhancement: rename push command argument as "remote_branch"

### DIFF
--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -46,19 +46,22 @@ class GsPushCommand(WindowCommand, PushBase):
     """
 
     def run(self, force=False):
+        self.force = force
+        sublime.set_timeout_async(self.run_async)
+
+    def run_async(self):
         savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         current_local_branch = self.get_current_branch_name()
         upstream = self.get_upstream_for_active_branch()
         if upstream:
             remote, remote_branch = upstream.split("/", 1)
-            sublime.set_timeout_async(
-                lambda: self.do_push(
-                    remote, current_local_branch, remote_branch=remote_branch, force=force))
+            self.do_push(
+                remote, current_local_branch, remote_branch=remote_branch, force=self.force)
         elif savvy_settings.get("prompt_for_tracking_branch"):
             if sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT):
                 self.window.run_command("gs_push_to_branch_name", {
                     "set_upstream": True,
-                    "force": force
+                    "force": self.force
                     })
         else:
             # if `prompt_for_tracking_branch` is false, ask for a remote and perform
@@ -66,7 +69,7 @@ class GsPushCommand(WindowCommand, PushBase):
             self.window.run_command("gs_push_to_branch_name", {
                                 "branch_name": current_local_branch,
                                 "set_upstream": False,
-                                "force": force
+                                "force": self.force
                                 })
 
 

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -44,7 +44,7 @@ class RemotesMixin():
         """
         self.git("pull", remote, branch)
 
-    def push(self, remote=None, branch=None, force=False, local_branch=None, set_upstream=False):
+    def push(self, remote=None, branch=None, force=False, remote_branch=None, set_upstream=False):
         """
         Push to the specified remote and branch if provided, otherwise
         perform default `git push`.
@@ -54,7 +54,7 @@ class RemotesMixin():
             "--force" if force else None,
             "--set-upstream" if set_upstream else None,
             remote,
-            branch if not local_branch else "{}:{}".format(local_branch, branch)
+            branch if not remote_branch else "{}:{}".format(branch, remote_branch)
             )
 
     def project_name_from_url(self, input_url):


### PR DESCRIPTION
Enhancement: rename push command argument as "remote_branch" and minor refactoring of PushBase.


Previously, the [push][1] command will do 

1. `git push remote local_branch:branch` if `local_branch` is not empty
2. `git push remote branch` if `local_branch` is empty

I found that it is a kind of counterintuitive, now, the function is refactored such that

1. `git push remote branch:remote_branch` if `remote_branch` is not empty
2. `git push remote branch` if `remote_branch` is empty


Additionally, I have refactored some logic of [GsPushCommand][2] to make it more straightforward.

[1]: https://github.com/randy3k/GitSavvy/blob/7df4d5a449d295ab9723056fc71579c49693cc01/core/git_mixins/remotes.py#L57
[2]: https://github.com/randy3k/GitSavvy/blob/4fb608a15fd0ee94e0b41551e74ff25d654f02c2/core/commands/push.py#L48