### PR TITLE
Fix: check if the current dashboard is on the list

### DIFF
--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -29,6 +29,8 @@ class GsTabCycleCommand(TextCommand, GitCommand):
 
     def run_async(self, source, target, reverse):
         to_load = target or self.get_next(source, reverse)
+        if not to_load:
+            return
         view_signature = self.view_signatures[to_load]
 
         self.view.window().run_command("hide_panel", {"cancel": True})
@@ -43,6 +45,9 @@ class GsTabCycleCommand(TextCommand, GitCommand):
 
         if reverse is True:
             tab_order.reverse()
+
+        if source not in tab_order:
+            return None
 
         source_idx = tab_order.index(source)
         next_idx = 0 if source_idx == len(tab_order) - 1 else source_idx + 1


### PR DESCRIPTION
The following error occurs if `tab_order` is set as
```
    "tab_order": ["status", "rebase", "graph"]
```
and <kbd>tab</kbd> is prssed on the Branch dashboard.

```
Traceback (most recent call last):
  File "/Users/Randy/Documents/Sublime Text 3/Packages/GitSavvy/core/interfaces/__init__.py", line 28, in <lambda>
    sublime.set_timeout_async(lambda: self.run_async(source, target, reverse))
  File "/Users/Randy/Documents/Sublime Text 3/Packages/GitSavvy/core/interfaces/__init__.py", line 31, in run_async
    to_load = target or self.get_next(source, reverse)
  File "/Users/Randy/Documents/Sublime Text 3/Packages/GitSavvy/core/interfaces/__init__.py", line 47, in get_next
    source_idx = tab_order.index(source)
ValueError: 'branch' is not in list
```

It is becaused the `branch_view` is not in `tab_order`.