### PR TITLE
Feature: show current file history

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -225,6 +225,10 @@
         "args": { "current_file": true }
     },
     {
+        "caption": "git: show current file at commit",
+        "command": "gs_show_current_file"
+    },
+    {
         "caption": "git: merge",
         "command": "gs_merge"
     },

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -4,6 +4,7 @@ from sublime_plugin import WindowCommand, TextCommand
 
 from ..git_command import GitCommand
 from ...common import util
+from .log import GsLogBase
 
 SHOW_COMMIT_TITLE = "COMMIT: {}:{}"
 
@@ -11,6 +12,14 @@ SHOW_COMMIT_TITLE = "COMMIT: {}:{}"
 class GsShowFileAtCommitCommand(WindowCommand, GitCommand):
 
     def run(self, commit_hash, filepath, lineno=1, lang=None):
+        sublime.set_timeout_async(
+            lambda: self.run_async(
+                commit_hash=commit_hash,
+                filepath=filepath,
+                lineno=lineno,
+                lang=lang))
+
+    def run_async(self, commit_hash, filepath, lineno=1, lang=None):
         # need to get repo_path before the new view is created.
         repo_path = self.repo_path
         view = util.view.get_scratch_view(self, "show_file_at_commit")
@@ -33,3 +42,30 @@ class GsShowFileAtCommitCommand(WindowCommand, GitCommand):
         view.run_command("gs_replace_view_text", {"text": content, "nuke_cursors": True})
         lineno = view.settings().get("git_savvy.show_file_at_commit_view.lineno")
         util.view.move_cursor(view, lineno, 0)
+
+
+class GsShowCurrentFileAtCommitCommand(GsShowFileAtCommitCommand):
+
+    def run(self, commit_hash, lineno=1, lang=None):
+        if not lang:
+            lang = self.window.active_view().settings().get('syntax')
+        super().run(
+            commit_hash=commit_hash,
+            filepath=self.file_path,
+            lineno=lineno,
+            lang=lang)
+
+
+class GsShowCurrentFileCommand(GsLogBase):
+    """
+    Show a panel of commits of current file on current branch and
+    then open the file at the selected commit.
+    """
+
+    def run(self):
+        super().run(file_path=self.file_path)
+
+    def do_action(self, commit_hash):
+        self.window.run_command("gs_show_current_file_at_commit", {
+            "commit_hash": commit_hash
+        })


### PR DESCRIPTION
Showing current file history, it is essentially a shortcut of `git: log current file` -> `For current branch` -> `show file at commit`.