### PR TITLE
Fix: git push all tags from non-interface view

### DIFF
--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -306,8 +306,9 @@ class GsTagPushCommand(TextCommand, GitCommand):
         sublime.status_message(END_PUSH_MESSAGE)
 
         interface = ui.get_interface(self.view.id())
-        interface.remotes = None
-        util.view.refresh_gitsavvy(self.view)
+        if interface:
+            interface.remotes = None
+            util.view.refresh_gitsavvy(self.view)
 
 
 class GsTagViewLogCommand(TextCommand, GitCommand):


### PR DESCRIPTION
When triggering the command `git: push all tags` in a non-interface view, `interface` would be `none`.