### PR TITLE
Stash unstaged files only

### DIFF
--- a/core/git_mixins/stash.py
+++ b/core/git_mixins/stash.py
@@ -35,7 +35,7 @@ class StashMixin():
         """
         Create stash with provided description from working files.
         """
-        self.git("stash", "save", "-u" if include_untracked else None, description)
+        self.git("stash", "save", "-k", "-u" if include_untracked else None, description)
 
     def drop_stash(self, id):
         """


### PR DESCRIPTION
The `GsStatusCreateStashCommand` and `GsStatusCreateStashWithUntrackedCommand` commands are (according to the comments) meant to create stash from unstaged changes - for that, the `-k` flag is needed.

Stashing only the unstaged changes does indeed make more sense.