### PR TITLE
Fix: support parsing "git://" remote URI to Github URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 
 # added by GitSavvy
 __pycache__/
+*.pyc
+.cache
 
 # added by GitSavvy
 /GitSavvy.sublime-workspace


### PR DESCRIPTION
This commit also logs an error in case parsing fails.

Fix #612