### PR TITLE
Fix: Clone doesn't need to be executed from a git repo

### DIFF
--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -128,7 +128,7 @@ class GsClone(WindowCommand, GitCommand):
 
     def do_clone(self):
         sublime.status_message("Start cloning {}".format(self.git_url))
-        self.git("clone", self.git_url, self.suggested_git_root)
+        self.git("clone", self.git_url, self.suggested_git_root, working_dir = '.')
         sublime.status_message("Cloned repo successfully.")
         self.open_folder()
         util.view.refresh_gitsavvy(self.window.active_view())


### PR DESCRIPTION
Fix #613