### PR TITLE
do not check if HEAD is rebased

### DIFF
--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -470,7 +470,7 @@ class RewriteBase(TextCommand, GitCommand):
         if not self.interface.preserve_merges() and self.interface.contain_merges():
 
             sublime.message_dialog(
-                "Unble to manipulate merge commits unless in preserve merges mode."
+                "Unable to manipulate merge commits unless in preserve merges mode."
             )
             return
 
@@ -680,7 +680,7 @@ class GsRebaseMoveUpCommand(RewriteBase):
             return
 
         if self.interface.entries[0].short_hash == short_hash:
-            sublime.status_message("Unable to move first commit up.")
+            sublime.message_dialog("Unable to move first commit up.")
             return
 
         move_idx, move_entry, _ = self.get_idx_entry_and_prev(short_hash)
@@ -727,7 +727,7 @@ class GsRebaseMoveDownCommand(RewriteBase):
             return
 
         if self.interface.entries[-1].short_hash == short_hash:
-            sublime.status_message("Unable to move last commit down.")
+            sublime.message_dialog("Unable to move last commit down.")
             return
 
         move_idx, move_entry, _ = self.get_idx_entry_and_prev(short_hash)

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -176,7 +176,7 @@ class RebaseInterface(ui.Interface, GitCommand):
         try:
             cursor_entry = log[cursor]
         except IndexError:
-            return "Rebase first." if self.is_not_rebased() else "Ready."
+            return "Not rebased." if self.is_not_rebased() else "Ready."
 
         if cursor == log_len - 1:
             return "Successfully {}. Undo available.".format(cursor_entry["description"])
@@ -336,8 +336,7 @@ class RebaseInterface(ui.Interface, GitCommand):
         return self._base_commit
 
     def is_not_rebased(self):
-        return self.git("merge-base", self.base_commit(), "HEAD").strip() != \
-                self.git("rev-parse", self.base_ref()).strip()
+        return self.base_commit() != self.git("rev-parse", self.base_ref()).strip()
 
     def contain_merges(self):
         count = self.git("rev-list", "--count", "{}..HEAD".format(self.base_commit())).strip()
@@ -468,11 +467,10 @@ class RewriteBase(TextCommand, GitCommand):
     def run(self, edit):
         self.interface = ui.get_interface(self.view.id())
 
-        if self.interface.is_not_rebased() or \
-                (not self.interface.preserve_merges() and self.interface.contain_merges()):
+        if not self.interface.preserve_merges() and self.interface.contain_merges():
 
             sublime.message_dialog(
-                "Unable to manipulate commits, rebase first."
+                "Unble to manipulate merge commits unless in preserve merges mode."
             )
             return
 

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -543,13 +543,13 @@ class GsRebaseSquashCommand(RewriteBase):
 
         # Cannot squash first commit.
         if self.interface.entries[0].short_hash == short_hash:
-            sublime.status_message("Unable to squash first commit.")
+            sublime.message_dialog("Unable to squash first commit.")
             return
 
         squash_idx, squash_entry, _ = self.get_idx_entry_and_prev(short_hash)
 
         if self.commit_is_merge(squash_entry.long_hash):
-            sublime.status_message("Unable to squash a merge.")
+            sublime.message_dialog("Unable to squash a merge.")
             return
 
         self.squash_idx = squash_idx
@@ -568,7 +568,7 @@ class GsRebaseSquashCommand(RewriteBase):
             self.get_idx_entry_and_prev(self.get_short_hash(target_commit))
 
         if self.commit_is_merge(target_entry.long_hash):
-            sublime.status_message("Unable to squash a merge.")
+            sublime.message_dialog("Unable to squash a merge.")
             return
 
         # Generate identical change templates with author/date metadata in tact.
@@ -594,6 +594,10 @@ class GsRebaseSquashCommand(RewriteBase):
 class GsRebaseSquashAllCommand(RewriteBase):
 
     def run_async(self):
+        for entry in self.interface.entries:
+            if self.commit_is_merge(entry.long_hash):
+                sublime.message_dialog("Unable to squash a merge.")
+                return
 
         # Generate identical change templates with author/date metadata
         # in tact.  However, set do_commit to false for all but the last change,


### PR DESCRIPTION
It is not necessary to check if HEAD is rebased. Manuplicating commits should be always possible (if there are no merges).


close #619

