### PR TITLE
Docs: Add OS type and version in bug information requested

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Please include the following information when filing a bug:
 
 - Sublime Text version number
 - Git version number
+- OS type and version
 - Console error output
 - A description of the problem.
 - Steps to reproduce, if possible.


### PR DESCRIPTION
Often needed to debug the user's underlying systems, since
both Python and Git communicate to each OS differently.