### PR TITLE
Improvement: refresh status bar and related fix

### DIFF
--- a/common/global_events.py
+++ b/common/global_events.py
@@ -10,7 +10,8 @@ class GsInterfaceFocusEventListener(EventListener):
     """
 
     def on_activated(self, view):
-        util.view.refresh_gitsavvy(view)
+        # status bar is handled by GsStatusBarEventListener
+        util.view.refresh_gitsavvy(view, refresh_status_bar=False)
 
     def on_close(self, view):
         util.view.handle_closed_view(view)

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -58,7 +58,7 @@ def get_is_view_of_type(view, typ):
 # GLOBAL #
 ##########
 
-def refresh_gitsavvy(view, refresh_sidebar=False):
+def refresh_gitsavvy(view, refresh_sidebar=False, refresh_status_bar=True):
     """
     Called after GitSavvy action was taken that may have effected the
     state of the Git repo.
@@ -68,7 +68,9 @@ def refresh_gitsavvy(view, refresh_sidebar=False):
     if view.settings().get("git_savvy.branch_commit_history_view") is not None:
         view.run_command("gs_branches_diff_commit_history_refresh")
 
-    view.run_command("gs_update_status_bar")
+    if refresh_status_bar:
+        view.run_command("gs_update_status_bar")
+
     if view.window() and refresh_sidebar:
         view.window().run_command("refresh_folder_list")
 

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -35,7 +35,7 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
         global last_execution, update_status_bar_soon
         if sublime.load_settings("GitSavvy.sublime-settings").get("git_status_in_status_bar"):
 
-            millisec = int(round(time.time() * 100))
+            millisec = int(round(time.time() * 1000))
             # If we updated to less then 100 ms we don't need to update now but
             # should update in 100 ms in case of current file change.
             #
@@ -50,7 +50,7 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
                     update_status_bar_soon = True
                     sublime.set_timeout_async(self.run_async, 100)
 
-            last_execution = int(round(time.time() * 100))
+            last_execution = int(round(time.time() * 1000))
 
     def run_async(self):
         # Short-circuit update attempts for files not part of Git repo.


### PR DESCRIPTION
Do not refresh status bar using `GsInterfaceFocusEventListener`, it is handled by `GsStatusBarEventListener` already.