### PR TITLE
Adds a setting to disable git init prompts

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -306,5 +306,11 @@
         When set to `true`, all views will hide their help menu when rendering.
         You can still toggle the help menu by pressing `?`.
      */
-    "hide_help_menu": false
+    "hide_help_menu": false,
+
+    /*
+        When set to `true`, no views will receive the prompt asking to initialize
+        Git in the current view's directory when not found.
+     */
+    "disable_git_init_prompt": false
 }

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -34,6 +34,10 @@ class GsOfferInit(WindowCommand):
     """
 
     def run(self):
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        if savvy_settings.get("disable_git_init_prompt"):
+            return
+
         active_view_id = self.window.active_view().id()
         if active_view_id not in views_with_offer_made and sublime.ok_cancel_dialog(NO_REPO_MESSAGE):
             self.window.run_command("gs_init")


### PR DESCRIPTION
As discussed in #589 and solves #664.

This could probably also have been implemented directly in [core/git_command.py](https://github.com/divmain/GitSavvy/blob/2b10772530437f7088f8fcebdba459f05efb2c7c/core/git_command.py#L101).

Feel free to squash or make any changes.