### PR TITLE
Enable maintainerd

### DIFF
--- a/.maintainerd
+++ b/.maintainerd
@@ -1,0 +1,57 @@
+log: true
+pullRequest:
+  preamble: >
+    The maintainers of this repo require that all pull request submitters agree and adhere
+    to the following:
+  items:
+    - prompt: >
+        I have read and agree to the
+        [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
+      default: false
+      required: true
+    - prompt: All related documentation has been updated to reflect the changes made.
+      default: false
+      required: true
+    - prompt: My commit messages are cleaned up and ready to merge.
+      default: false
+      required: true
+  semver:
+    enabled: true
+    # Not yet implemented:
+    autodetect: true
+commit:
+  subject:
+    mustHaveLengthBetween: [8, 72]
+    mustMatch: !!js/regexp /^(Fix|Enhancement|Feature|Internal|Other):\s.*/
+    mustNotMatch: !!js/regexp /^fixup!/
+  message:
+    enforceEmptySecondLine: true
+    linesMustHaveLengthBetween: [0, 72]
+issue:
+  onLabelAdded:
+    not-enough-information:
+      action: comment
+      data: |
+        This issue has been tagged with the `not-enough-information` label.  In order for us to help you, please respond with the following information:
+
+        - A description of the problem, including any relevant error output that you find in the Sublime console.
+        - Steps to reproduce, if possible.
+        - The path of the `git` variable that GitSavvy detects.
+        - The path that `GitSavvy` is configured to use (optional).
+        - The operating system that you are using.
+
+        To save time, you can determine much of this by opening the Sublime console (press ``Ctrl-` ``) and pasting the following into the provided box:
+
+        ```python
+        import shutil, sys, sublime; print("which git:", shutil.which("git")); print("os:", sys.platform); print("sublime version:", sublime.version()); print("GitSavvy git:", sublime.load_settings("GitSavvy.sublime-settings").get("git_path"))
+        ```
+
+        Additionally, if you are reporting a bug that only occurs in specific circumstances, please also do the following:
+
+        - Open the command palette (either `Cmd-Shift-P` or `Ctrl-Shift-P`) and enter `GitSavvy: enable logging`
+        - Go ahead and reproduce the incorrect behavior.
+        - Open the command palette again and enter `GitSavvy: disable logging`.
+        - Open the command palette a final time and enter `GitSavvy: view recorded log`.
+        - Copy the log output and included it in this ticket (inside triple-backticks - ```` ``` ````).
+
+        If we receive no response to this issue within 2 weeks, the issue will be closed.  If that happens, feel free to re-open with the requested information.  Thank you!

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,11 @@ after_success:
       fi
     - coveralls
 
+deploy:
+  provider: script
+  script: scripts/deploy.sh
+  on:
+    branch: master
+
 notifications:
     email: false

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,33 @@
+PULL_REQUEST_NUMBER=$(git show HEAD --format=format:%s | sed -nE 's/Merge pull request #([0-9]+).*/\1/p')
+if [ -z "$PULL_REQUEST_NUMBER" ]; then
+    echo "No pull request number found; aborting publish."
+else
+    SEMVER_CHANGE=$(curl "https://maintainerd.divmain.com/api/semver?repoPath=divmain/GitSavvy&installationId=31333&prNumber=$PULL_REQUEST_NUMBER")
+    if [ -z "$SEMVER_CHANGE" ]; then
+        echo "No semver selection found; aborting publish."
+    else
+        MOST_RECENT_TAG=$(git describe --abbrev=0)
+        VERSION_ARRAY=( ${MOST_RECENT_TAG//./ } )
+
+        if [ "$SEMVER_CHANGE" == "major" ]; then
+            ((VERSION_ARRAY[0]++))
+            VERSION_ARRAY[1]=0
+            VERSION_ARRAY[2]=0
+        elif [ "$SEMVER_CHANGE" == "minor" ]; then
+            ((VERSION_ARRAY[1]++))
+            VERSION_ARRAY[2]=0
+        elif [ "$SEMVER_CHANGE" == "patch" ]; then
+            ((VERSION_ARRAY[2]++))
+        else
+            echo "Matching semantic version not found; aborting publish."
+        fi
+
+        git config --global user.name "Dale Bustad (automated)"
+        git config --global user.email "dale@divmain.com"
+
+        git tag -a "${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}.${VERSION_ARRAY[2]}" -m "v${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}.${VERSION_ARRAY[2]}"
+
+        git remote add origin-deploy https://${GH_TOKEN}@github.com/divmain/GitSavvy.git > /dev/null 2>&1
+        git push --quiet --tags origin-deploy master
+    fi
+fi


### PR DESCRIPTION
Alright @stoivo @asfaltboy @randy3k, this thing is ready for a test run.  What this will do:

1. Auto-edit the description of new pull requests with the following checkboxes:
  a. I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
  b. All related documentation has been updated to reflect the changes made.
  c. My commit messages are cleaned up and ready to merge.
2. Require that all of these checkboxes are checked off before CI goes green.
3. Requires the submitter (or one of the maintainers) to select a semantic version that corresponds with the change represented by the pull request.
4. Enforce formatting guidelines for commit subjects:
  a. They must be between 8 and 72 characters long.
  b. They must start with one of `Fix`, `Enhancement`, `Feature`, `Internal`, or `Other`, followed by a colon.
5. Enforce formatting guidelines for commit messages:
  a. If multi-line, the second line must be empty.
  b. If multi-line all lines musts be between 0 and 72 characters long.
6. Auto-post a message asking the submitter for more information when the `not-enough-information` label is added to an issue.

Finally, it exposes as API to retrieve the selected semantic version for a given PR.  In CI, we can use this API to determine how to bump the version number, do that automatically, generate the release notes from the commit message, and push the new tag back to `origin`.  This will completely automate our release process, at the granularity of a PR.

Down the line, I'll be adding auto-closing of issues that have been labeled `not-enough-information` and which have received no reply after a specified period of time.

All of this came out of my need to streamline the maintenance process for my OSS projects: primarily [freactal](http://github.com/FormidableLabs/freactal), [Rapscallion](http://github.com/FormidableLabs/rapscallion), and GitSavvy.  I have a couple of other projects in the pipeline, and I wanted to get maintainerd more or less working before they are released.

Definitely interested in your feedback here.  Particular rules can be tweaked or removed.  And if you have ideas for other busywork that could be automated away, let me know and I'll include it.  maintainerd will see a public release after its been vetted on my own projects for a bit.

Thanks!

-----

Semver selection for auto-publish purposes:

- [x] <!-- semver --> patch