### PR TITLE
Enhancement: compare against now accept both base/target commits

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -196,12 +196,13 @@
     },
     {
         "caption": "git: compare against ...",
-        "command": "gs_compare_against"
+        "command": "gs_compare_against",
+        "args": { "target_commit": "HEAD" }
     },
     {
         "caption": "git: compare current file against ...",
         "command": "gs_compare_against",
-        "args": { "current_file": true }
+        "args": { "target_commit": "HEAD", "current_file": true }
     },
     {
         "caption": "git: blame current file",


### PR DESCRIPTION
The commit b7359f0 in PR #694 is not good enough. In this PR, I have extended `gs_compare_against` to accept both `base_commit` and `target_commit`. Only one of them should be specified. The panel prompt will ask for another commit and automatically fill in the missing one.
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

