### PR TITLE
Enhancement: disable "stage all" if there is merge conflict

### DIFF
--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -465,6 +465,10 @@ class GsStatusStageAllFilesCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
+        interface = ui.get_interface(self.view.id())
+        if interface.conflict_entries:
+            return
+
         self.add_all_tracked_files()
         util.view.refresh_gitsavvy(self.view)
 
@@ -476,6 +480,10 @@ class GsStatusStageAllFilesWithUntrackedCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
+        interface = ui.get_interface(self.view.id())
+        if interface.conflict_entries:
+            return
+
         self.add_all_files()
         util.view.refresh_gitsavvy(self.view)
 


### PR DESCRIPTION
The [A] key in Status dashboard stages file and the [A] key in Rebase dashboard aborts rebase.

When using the Status dashboard and there are merge conflicts, I very often will accidentally press the [A] key and think that it will abort the merge. This PR will avoid such a mistake.

Not sure if it is practical for others. I personally don't do "stage all" if there are merge conflicts, instead, I will stage the conflicted files individually.

Would like to hear how others think.
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

