### PR TITLE
Fix: find_git_root handles multiple folders

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -230,6 +230,32 @@ class GitCommand(StatusMixin,
 
         return None
 
+    def find_repo_path(self, throw_on_stderr=False):
+        """
+        Similar to find_working_dir, except that it does not stop on the first
+        directory found, rather on the first git repository found.
+        """
+        view = self.window.active_view() if hasattr(self, "window") else self.view
+        file_name = view.file_name()
+        repo_path = None
+
+        # try the current file first
+        if file_name:
+            file_dir = os.path.dirname(file_name)
+            if os.path.isdir(file_dir):
+                repo_path = self.find_git_toplevel(file_dir, throw_on_stderr=False)
+
+        # fallback: use the first folder if the current file is not inside a git repo
+        if not repo_path:
+            window = view.window()
+            if window:
+                folders = window.folders()
+                if folders and os.path.isdir(folders[0]):
+                    # we don't set "git_savvy.repo_path" for a out-of-git-repo file
+                    repo_path = self.find_git_toplevel(
+                        folders[0], throw_on_stderr=throw_on_stderr)
+        return repo_path
+
     def find_git_toplevel(self, folder, throw_on_stderr):
         stdout = self.git(
             "rev-parse",
@@ -263,35 +289,17 @@ class GitCommand(StatusMixin,
         # The below condition will be true if run from a WindowCommand and false
         # from a TextCommand.
         view = self.window.active_view() if hasattr(self, "window") else self.view
-        repo_path = view.settings().get("git_savvy.repo_path")
+        repo_path = view.settings().get("git_savvy.repo_path") if view else None
 
         if not repo_path or not os.path.exists(repo_path):
-            file_name = view.file_name()
-
-            # try the current file first
-            if file_name:
-                file_dir = os.path.dirname(file_name)
-                if os.path.isdir(file_dir):
-                    repo_path = self.find_git_toplevel(file_dir, throw_on_stderr=False)
-                    # only set `git_savvy.repo_path` for current file
-                    if repo_path:
-                        view.settings().set("git_savvy.repo_path", os.path.realpath(repo_path))
-
-            # fallback: use the first folder if the current file is not inside a git repo
-            if not repo_path:
-                window = view.window()
-                if window:
-                    folders = window.folders()
-                    if folders and os.path.isdir(folders[0]):
-                        # we don't set "git_savvy.repo_path" for a out-of-git-repo file
-                        repo_path = self.find_git_toplevel(
-                            folders[0], throw_on_stderr=throw_on_stderr)
-
+            repo_path = self.find_repo_path(throw_on_stderr=throw_on_stderr)
             if not repo_path:
                 if throw_on_stderr:
                     raise ValueError("Unable to determine Git repo path.")
                 else:
                     return None
+            else:
+                view.settings().set("git_savvy.repo_path", os.path.realpath(repo_path))
 
         return os.path.realpath(repo_path) if repo_path else repo_path
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -247,7 +247,7 @@ class GitCommand(StatusMixin,
 
         # fallback: use the first folder if the current file is not inside a git repo
         if not repo_path:
-            window = view.window()
+            window = sublime.active_window()
             if window:
                 folders = window.folders()
                 if folders and os.path.isdir(folders[0]):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -220,10 +220,12 @@ class GitCommand(StatusMixin,
 
         file_path = view.file_name()
         if file_path:
-            return os.path.dirname(file_path)
+            file_dir = os.path.dirname(file_path)
+            if os.path.isdir(file_dir):
+                return os.path.dirname(file_path)
 
         open_folders = view.window().folders()
-        if open_folders:
+        if open_folders and os.path.isdir(open_folders[0]):
             return open_folders[0]
 
         return None
@@ -268,18 +270,19 @@ class GitCommand(StatusMixin,
 
             # try the current file first
             if file_name:
-                repo_path = self.find_git_toplevel(
-                    os.path.dirname(file_name), throw_on_stderr=False)
-                # only set `git_savvy.repo_path` for current file
-                if repo_path:
-                    view.settings().set("git_savvy.repo_path", os.path.realpath(repo_path))
+                file_dir = os.path.dirname(file_name)
+                if os.path.isdir(file_dir):
+                    repo_path = self.find_git_toplevel(file_dir, throw_on_stderr=False)
+                    # only set `git_savvy.repo_path` for current file
+                    if repo_path:
+                        view.settings().set("git_savvy.repo_path", os.path.realpath(repo_path))
 
             # fallback: use the first folder if the current file is not inside a git repo
             if not repo_path:
                 window = view.window()
                 if window:
                     folders = window.folders()
-                    if folders:
+                    if folders and os.path.isdir(folders[0]):
                         # we don't set "git_savvy.repo_path" for a out-of-git-repo file
                         repo_path = self.find_git_toplevel(
                             folders[0], throw_on_stderr=throw_on_stderr)


### PR DESCRIPTION
Fix #718 and the hope to also address #716 

The fix in #712 doesn't handle multiple folders. Git root is now detected in the following logic

1. if the current file is in a repo, use that repo
2. if sidebar exists and the first folder is in a repo, use that repo
3. if sidebar exists, show the initialization popup
4. else, show "Unable to determine Git repo path."

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only
