### PR TITLE
Feature: find matching line when showing current file

### DIFF
--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -198,49 +198,6 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
 
         sublime.set_timeout_async(lambda: self.verify_not_conflict(), 0)
 
-    def get_indexed_file_object(self, file_path):
-        """
-        Given an absolute path to a file contained in a git repo, return
-        git's internal object hash associated with the version of that file
-        in the index (if the file is staged) or in the HEAD (if it is not
-        staged).
-        """
-        stdout = self.git("ls-files", "-s", file_path)
-
-        # 100644 c9d70aa928a3670bc2b879b4a596f10d3e81ba7c 0   SomeFile.py
-        #        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        git_file_entry = stdout.split(" ")
-        return git_file_entry[1]
-
-    def get_head_file_object(self, file_path):
-        """
-        Given an absolute path to a file contained in a git repo, return
-        git's internal object hash associated with the version of that
-        file in the HEAD.
-        """
-        stdout = self.git("ls-tree", "HEAD", file_path)
-
-        # 100644 blob 7317069f30eafd4d7674612679322d59f9fb65a4    SomeFile.py
-        #             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        git_file_entry = stdout.split()  # split by spaces and tabs
-        return git_file_entry[2]
-
-    def get_object_contents(self, object_hash):
-        """
-        Given the object hash to a versioned object in the current git repo,
-        display the contents of that object.
-        """
-        return self.git("show", "--no-color", object_hash)
-
-    def get_object_from_string(self, string):
-        """
-        Given a string, pipe the contents of that string to git and have it
-        stored in the current repo, and return an object-hash that can be
-        used to diff against.
-        """
-        stdout = self.git("hash-object", "-w", "--stdin", stdin=string, encode=False)
-        return stdout.split("\n")[0]
-
     def get_inline_diff_contents(self, original_contents, diff):
         """
         Given a file's original contents and an array of hunks that could be

--- a/core/commands/show_file_at_commit.py
+++ b/core/commands/show_file_at_commit.py
@@ -47,9 +47,12 @@ class GsShowFileAtCommitCommand(WindowCommand, GitCommand):
 
 class GsShowCurrentFileAtCommitCommand(GsShowFileAtCommitCommand):
 
-    def run(self, commit_hash, lineno=1, lang=None):
+    @util.view.single_cursor_coords
+    def run(self, coords, commit_hash, lineno=None, lang=None):
         if not lang:
             lang = self.window.active_view().settings().get('syntax')
+        if lineno is None:
+            lineno = self.find_matching_lineno(None, commit_hash, coords[0] + 1)
         super().run(
             commit_hash=commit_hash,
             filepath=self.file_path,


### PR DESCRIPTION
This one should be easier to review. It matches current line of the current file when using `show current file at commit`.

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only