### PR TITLE
Fix: avoid setting repo_path when a file is not in the repo

### DIFF
--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -53,14 +53,15 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
             last_execution = int(round(time.time() * 1000))
 
     def run_async(self):
-        # Short-circuit update attempts for files not part of Git repo.
-        if not self._repo_path(throw_on_stderr=False):
-            self.view.erase_status("gitsavvy-repo-status")
-            return
-
+        # disable logging and git raise error
         with debug.disable_logging():
-            short_status = self.get_branch_status_short()
-        self.view.set_status("gitsavvy-repo-status", short_status)
+            # ignore all other possible errors
+            try:
+                self.repo_path  # check for ValueError
+                short_status = self.get_branch_status_short()
+                self.view.set_status("gitsavvy-repo-status", short_status)
+            except Exception as e:
+                self.view.erase_status("gitsavvy-repo-status")
 
         global update_status_bar_soon
         update_status_bar_soon = False

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -236,12 +236,11 @@ class GitCommand(StatusMixin,
         directory found, rather on the first git repository found.
         """
         view = self.window.active_view() if hasattr(self, "window") else self.view
-        file_name = view.file_name()
         repo_path = None
 
         # try the current file first
-        if file_name:
-            file_dir = os.path.dirname(file_name)
+        if view and view.file_name():
+            file_dir = os.path.dirname(view.file_name())
             if os.path.isdir(file_dir):
                 repo_path = self.find_git_toplevel(file_dir, throw_on_stderr=False)
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -251,10 +251,10 @@ class GitCommand(StatusMixin,
             if window:
                 folders = window.folders()
                 if folders and os.path.isdir(folders[0]):
-                    # we don't set "git_savvy.repo_path" for a out-of-git-repo file
                     repo_path = self.find_git_toplevel(
                         folders[0], throw_on_stderr=throw_on_stderr)
-        return repo_path
+
+        return os.path.realpath(repo_path) if repo_path else None
 
     def find_git_toplevel(self, folder, throw_on_stderr):
         stdout = self.git(
@@ -298,8 +298,11 @@ class GitCommand(StatusMixin,
                     raise ValueError("Unable to determine Git repo path.")
                 else:
                     return None
-            else:
-                view.settings().set("git_savvy.repo_path", os.path.realpath(repo_path))
+            elif view:
+                file_name = view.file_name()
+                # only set "git_savvy.repo_path" when the current file is in repo_path
+                if file_name and os.path.realpath(file_name).startswith(repo_path + os.path.sep):
+                    view.settings().set("git_savvy.repo_path", repo_path)
 
         return os.path.realpath(repo_path) if repo_path else repo_path
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -236,6 +236,7 @@ class GitCommand(StatusMixin,
         directory found, rather on the first git repository found.
         """
         view = self.window.active_view() if hasattr(self, "window") else self.view
+        window = view.window() if view else None
         repo_path = None
 
         # try the current file first
@@ -246,7 +247,6 @@ class GitCommand(StatusMixin,
 
         # fallback: use the first folder if the current file is not inside a git repo
         if not repo_path:
-            window = sublime.active_window()
             if window:
                 folders = window.folders()
                 if folders and os.path.isdir(folders[0]):
@@ -293,11 +293,14 @@ class GitCommand(StatusMixin,
         if not repo_path or not os.path.exists(repo_path):
             repo_path = self.find_repo_path(throw_on_stderr=throw_on_stderr)
             if not repo_path:
-                if throw_on_stderr:
+                # don't throw error for detached view
+                view_is_detached = view and not view.window()
+                if not view_is_detached and throw_on_stderr:
                     raise ValueError("Unable to determine Git repo path.")
                 else:
                     return None
-            elif view:
+
+            if view:
                 file_name = view.file_name()
                 # only set "git_savvy.repo_path" when the current file is in repo_path
                 if file_name and os.path.realpath(file_name).startswith(repo_path + os.path.sep):

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -213,20 +213,17 @@ class GitCommand(StatusMixin,
 
     def find_working_dir(self):
         view = self.window.active_view() if hasattr(self, "window") else self.view
-        window = view.window()
+        window = view.window() if view else None
 
-        if not window:
-            return None
-
-        file_path = view.file_name()
-        if file_path:
-            file_dir = os.path.dirname(file_path)
+        if view and view.file_name():
+            file_dir = os.path.dirname(view.file_name())
             if os.path.isdir(file_dir):
-                return os.path.dirname(file_path)
+                return file_dir
 
-        open_folders = view.window().folders()
-        if open_folders and os.path.isdir(open_folders[0]):
-            return open_folders[0]
+        if window:
+            folders = window.folders()
+            if folders and os.path.isdir(folders[0]):
+                return folders[0]
 
         return None
 


### PR DESCRIPTION
continue the discussion in #719 for not setting "git_savvy.repo_path" if the current file is not in the found repo.

close #726
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

