### PR TITLE
Enhancement: disable "reset line" and "reset hunk" in inline diff cached mode

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -26,7 +26,8 @@
         "args": { "reset": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.inline_diff_view.in_cached_mode", "operator": "equal", "operand": false },
         ]
     },
     {
@@ -35,7 +36,8 @@
         "args": { "reset": true },
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.inline_diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.inline_diff_view.in_cached_mode", "operator": "equal", "operand": false },
         ]
     },
     {

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -61,7 +61,7 @@ class GsInlineDiffCommand(WindowCommand, GitCommand):
             file_ext = util.file.get_file_extension(os.path.basename(settings["git_savvy.file_path"]))
             self.augment_color_scheme(diff_view, file_ext)
 
-            diff_view.settings().set("git_savvy.inline_diff.cached", cached)
+            diff_view.settings().set("git_savvy.inline_diff_view.in_cached_mode", cached)
             for k, v in settings.items():
                 diff_view.settings().set(k, v)
 
@@ -142,7 +142,7 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
 
     def run(self, edit):
         file_path = self.file_path
-        in_cached_mode = self.view.settings().get("git_savvy.inline_diff.cached")
+        in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
         savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         ignore_eol_arg = (
             "--ignore-space-at-eol"
@@ -397,7 +397,7 @@ class GsInlineDiffStageOrResetBase(TextCommand, GitCommand):
         sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
 
     def run_async(self, reset=False):
-        in_cached_mode = self.view.settings().get("git_savvy.inline_diff.cached")
+        in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
         savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         ignore_ws = (
             "--ignore-whitespace"

--- a/popups/inline_diff_view.html
+++ b/popups/inline_diff_view.html
@@ -9,10 +9,10 @@
 <ul>
   <li><code><span class="shortcut-key">o&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>open file at hunk</code></li>
 
-  <li><code><span class="shortcut-key">l&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage line</code></li>
-  <li><code><span class="shortcut-key">h&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk</code></li>
-  <li><code><span class="shortcut-key">L&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset (unstage) line</code></li>
-  <li><code><span class="shortcut-key">H&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset (unstage) hunk</code></li>
+  <li><code><span class="shortcut-key">l&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage line / unstage line (in cached mode)</code></li>
+  <li><code><span class="shortcut-key">h&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk / unstage line (in cached mode)</code></li>
+  <li><code><span class="shortcut-key">L&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset line</code></li>
+  <li><code><span class="shortcut-key">H&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>reset hunk</code></li>
   <li><code><span class="shortcut-key">.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to next hunk</code></li>
   <li><code><span class="shortcut-key">,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>go to previous hunk</code></li>
 </ul>


### PR DESCRIPTION
The concept of reseting lines an hunks in cached mode is confusing. What it does now is exactly equal to unstaging lines or hunks. So, "l" and "L" (also "h" and "H") are doing the same task in the cached mode. This PR disables the "reset" keys "H" and "L" in the cached mode.

We actually also disabled "reset hunk" for the diff view, so it does also make sense to disable it for the inline diff view.
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

