### PR TITLE
Enhancement: limit of items in tags dashboard

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -159,6 +159,11 @@
     "show_remotes_in_tags_dashboard": false,
 
     /*
+        Limit the number of tags listed in the tags dashboard.
+    */
+    // "max_items_in_tags_dashboard": 10
+
+    /*
         When set to `true`, GitSavvy will offer to set the upstream on `git: push`
         when tracking branch is not configured.
      */

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -81,6 +81,7 @@ class TagsInterface(ui.Interface, GitCommand):
         if self.show_remotes is None:
             savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
             self.show_remotes = savvy_settings.get("show_remotes_in_tags_dashboard")
+            self.max_items = savvy_settings.get("max_items_in_tags_dashboard", None)
 
         self.local_tags = self.get_tags(reverse=True)
         if not self.remotes and self.show_remotes:
@@ -110,7 +111,7 @@ class TagsInterface(ui.Interface, GitCommand):
 
         return "\n".join(
             "    {} {}".format(self.get_short_hash(tag.sha), tag.tag)
-            for tag in self.local_tags
+            for tag in self.local_tags[0:self.max_items]
             )
 
     @ui.partial("remote_tags")
@@ -147,10 +148,11 @@ class TagsInterface(ui.Interface, GitCommand):
     def get_remote_tags_list(self, remote, remote_name):
         if "tags" in remote:
             if remote["tags"]:
-                msg = "\n".join(
-                    "    {} {}".format(self.get_short_hash(tag.sha), tag.tag)
-                    for tag in remote["tags"] if tag.tag[-3:] != "^{}"
-                    )
+                tags_list = [tag for tag in remote["tags"] if tag.tag[-3:] != "^{}"]
+                tags_list = tags_list[0:self.max_items]
+
+                msg = "\n".join("    {} {}".format(
+                    self.get_short_hash(tag.sha), tag.tag) for tag in tags_list)
             else:
                 msg = NO_REMOTE_TAGS_MESSAGE
 


### PR DESCRIPTION
I found that the tags dashboard is nearly useless if there are too many tags.

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only
