### PR TITLE
Fix: sort_by_recent_in_branch_dashboard breaks the branch order

### DIFF
--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -84,7 +84,6 @@ class BranchInterface(ui.Interface, GitCommand):
         sort_by_recent = savvy_settings.get("sort_by_recent_in_branch_dashboard")
         self._branches = tuple(self.get_branches(sort_by_recent))
 
-
     def on_new_dashboard(self):
         self.view.run_command("gs_branches_navigate_branch")
 
@@ -145,7 +144,9 @@ class BranchInterface(ui.Interface, GitCommand):
         output_tmpl = "\n"
         render_fns = []
 
-        for remote_name, branches in groupby(self._branches, lambda branch: branch.remote):
+        sorted_branches = sorted(
+            [b for b in self._branches if b.remote], key=lambda branch: branch.remote)
+        for remote_name, branches in groupby(sorted_branches, lambda branch: branch.remote):
             if not remote_name:
                 continue
 


### PR DESCRIPTION
The usage of `groupby` is broken if the branches are sorted by recency.

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only
