### PR TITLE
Enhancement: show diff stat in diff_view

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -182,7 +182,7 @@
         core/git_mixins/history.py |  8 ++------
         3 files changed, 10 insertions(+), 20 deletions(-)
 
-        Set to `false` if don't want to show this when view a commit.
+        Set to `false` if don't want to show this when view a commit or diff.
      */
     "show_diffstat": true,
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -47,6 +47,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
             "-" if base_commit is None else "--" + base_commit,
             file_path or repo_path
         )
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
 
         if view_key in diff_views and diff_views[view_key] in sublime.active_window().views():
             diff_view = diff_views[view_key]
@@ -63,6 +64,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
             diff_view.settings().set("git_savvy.diff_view.show_word_diff", False)
             diff_view.settings().set("git_savvy.diff_view.base_commit", base_commit)
             diff_view.settings().set("git_savvy.diff_view.target_commit", target_commit)
+            diff_view.settings().set("git_savvy.diff_view.show_diffstat", savvy_settings.get("show_diffstat", True))
             diff_view.settings().set("git_savvy.diff_view.disable_stage", disable_stage)
             diff_views[view_key] = diff_view
 
@@ -87,12 +89,15 @@ class GsDiffRefreshCommand(TextCommand, GitCommand):
         show_word_diff = self.view.settings().get("git_savvy.diff_view.show_word_diff")
         base_commit = self.view.settings().get("git_savvy.diff_view.base_commit")
         target_commit = self.view.settings().get("git_savvy.diff_view.target_commit")
+        show_diffstat = self.view.settings().get("git_savvy.diff_view.show_diffstat")
 
         try:
             stdout = self.git(
                 "diff",
                 "--ignore-all-space" if ignore_whitespace else None,
                 "--word-diff" if show_word_diff else None,
+                "--stat" if show_diffstat else None,
+                "--patch",
                 "--no-color",
                 "--cached" if in_cached_mode else None,
                 base_commit,

--- a/syntax/diff.sublime-syntax
+++ b/syntax/diff.sublime-syntax
@@ -95,3 +95,4 @@ contexts:
         2: markup.deleted.git-savvy.delete-block.content
         3: punctuation.definition.deleted.diff
 
+    - include: "scope:git-savvy.commit-diffstat"

--- a/syntax/show_commit.sublime-syntax
+++ b/syntax/show_commit.sublime-syntax
@@ -25,5 +25,4 @@ contexts:
       scope: meta.commit-header-and-stat-splitter
       comment: Separator between commit message and diffstat
 
-    - include: "scope:git-savvy.commit-diffstat"
     - include: "scope:git-savvy.diff"

--- a/syntax/show_commit_diffstat.sublime-syntax
+++ b/syntax/show_commit_diffstat.sublime-syntax
@@ -6,7 +6,7 @@ hidden: true
 scope: git-savvy.commit-diffstat
 contexts:
   main:
-    - match: ^ (.+) \| +(\d+) (\+*)(-*)$\n?
+    - match: ^ (\S.+) \| +(\d+) (\+*)(-*)$\n?
       comment: author and date info
       scope: meta.commit-info.diffstat.line
       captures:


### PR DESCRIPTION
diff stat is currently shown in `show_commit_view`, this PR makes it also available to `diff_view`. Also, contains a small tweak to the syntax files.
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

