### PR TITLE
Fix: always pull to the active branch

### DIFF
--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -92,6 +92,6 @@ class GsPullCommand(WindowCommand, GitCommand):
         Perform `git pull remote branch`.
         """
         sublime.status_message("Starting pull...")
-        self.pull(remote=remote, branch=branch, remote_branch=remote_branch, rebase=self.rebase)
+        self.pull(remote=remote, remote_branch=remote_branch, rebase=self.rebase)
         sublime.status_message("Pull complete.")
         util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -42,7 +42,7 @@ class RemotesMixin():
         # Remove any duplicate branch names.
         return [branch for idx, branch in enumerate(branches) if branches.index(branch) == idx]
 
-    def pull(self, remote=None, branch=None, remote_branch=None, rebase=False):
+    def pull(self, remote=None, remote_branch=None, rebase=False):
         """
         Pull from the specified remote and branch if provided, otherwise
         perform default `git pull`.
@@ -50,8 +50,8 @@ class RemotesMixin():
         self.git(
             "pull",
             "--rebase" if rebase else None,
-            remote,
-            branch if not remote_branch else "{}:{}".format(remote_branch, branch)
+            remote if remote else None,
+            remote_branch if remote and remote_branch else None
             )
 
     def push(self, remote=None, branch=None, force=False, remote_branch=None, set_upstream=False):


### PR DESCRIPTION
It may be confusing to pull to a branch other than the active branch

https://github.com/divmain/GitSavvy/issues/729#issuecomment-322219945

close #729

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only
