### PR TITLE
GitHub integration API limit

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -46,6 +46,11 @@
     },
 
     /*
+    maximum number of items per page when requesting from github
+    */
+    "github_per_page_max" : 100,
+
+    /*
         Change this to "full" to display a full diff for the current commit
         when writing a commit message.
 

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -113,7 +113,7 @@ class PanelCommandMixin(PanelActionMixin):
 
 
 def show_paginated_panel(items, on_done, flags=None, selected_index=None, on_highlight=None,
-                         limit=6000, next_message=None):
+                         limit=6000, format_item=None, next_message=None):
     """
     Display items in quick panel with pagination, and execute on_done
     when item is selected.
@@ -124,6 +124,8 @@ def show_paginated_panel(items, on_done, flags=None, selected_index=None, on_hig
     selected_index: an integer or a callable returning boolean.
                     If callable, takes either an integer or an entry.
     on_highlight: a callable, takes either an integer or an entry.
+
+    format_item: a function to format each item
 
     next_message: a message of next page, default is ">>> NEXT PAGE >>>"
 
@@ -140,6 +142,7 @@ def show_paginated_panel(items, on_done, flags=None, selected_index=None, on_hig
             selected_index=selected_index,
             on_highlight=on_highlight,
             limit=limit,
+            format_item=format_item,
             next_message=next_message)
     pp.show()
     return pp
@@ -161,9 +164,9 @@ class PaginatedPanel:
         self.item_generator = (item for item in items)
         self.on_done = on_done
         for option in ['flags', 'selected_index', 'on_highlight',
-                       'limit', 'next_message', ]:
-            # need to check the nullness of the options to avoid the default
-            # method `on_hightight` of LogPanel to be overrided.
+                       'limit', 'format_item', 'next_message', ]:
+            # need to check the nullness of the options to avoid overriding the default
+            # methods, e.g. `format_item` and `on_hightight` of LogPanel
             if option in kwargs and kwargs[option] is not None:
                 setattr(self, option, kwargs[option])
 

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -168,6 +168,8 @@ class PaginatedPanel:
     on_highlight = None
 
     def __init__(self, items, on_done, **kwargs):
+        self._is_empty = True
+        self._is_done = False
         self.skip = 0
         self.item_generator = (item for item in items)
         self.on_done = on_done
@@ -206,8 +208,14 @@ class PaginatedPanel:
             if self.status_message:
                 sublime.status_message("")
 
+        if self.display_list and self._is_empty:
+            self._is_empty = False
+
         if len(self.display_list) == self.limit:
             self.display_list.append(self.next_message)
+        else:
+            # done
+            self._is_done = True
 
         kwargs = {}
         if self.flags:
@@ -262,6 +270,12 @@ class PaginatedPanel:
     def on_selection(self, value):
         self.value = value
         self.on_done(value)
+
+    def is_empty(self):
+        return self._is_empty
+
+    def is_done(self):
+        return self._is_done
 
 
 def show_log_panel(entries, on_done, limit=6000, selected_index=None, on_highlight=None):

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -255,7 +255,7 @@ class PaginatedPanel:
     def _on_selection(self, index):
         if index == self.limit:
             self.skip = self.skip + self.limit
-            sublime.set_timeout(self.show, 10)
+            sublime.set_timeout_async(self.show, 10)
         elif self.ret_list:
             if index == -1:
                 self.on_selection(None)

--- a/github/commands/add_fork_as_remote.py
+++ b/github/commands/add_fork_as_remote.py
@@ -1,7 +1,9 @@
 import sublime
 from sublime_plugin import TextCommand
+from itertools import chain
 
 from ...core.git_command import GitCommand
+from ...core.ui_mixins.quick_panel import show_paginated_panel
 from .. import github
 from .. import git_mixins
 
@@ -18,37 +20,36 @@ class GsAddForkAsRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemotes
 
     def run_async(self):
         base_remote = github.parse_remote(self.get_integrated_remote_url())
-        forks = github.get_forks(base_remote)
         base_repo_data = github.get_repo_data(base_remote)
         parent = None
 
-        self.gh_remotes = []
-
+        forks = []
         if "parent" in base_repo_data:
-            parent = (base_repo_data["parent"]["full_name"],
-                      base_repo_data["parent"]["clone_url"],
-                      base_repo_data["parent"]["owner"]["login"])
-            self.gh_remotes.append(parent)
+            parent = base_repo_data["parent"]
+            forks.append(parent)
 
         if "source" in base_repo_data:
-            source = (base_repo_data["source"]["full_name"],
-                      base_repo_data["source"]["clone_url"],
-                      base_repo_data["source"]["owner"]["login"])
-            if not parent == source:
-                self.gh_remotes.append([source, "Source"])
+            source = base_repo_data["source"]
+            if not parent["clone_url"] == source["clone_url"]:
+                forks.append(source)
 
-        self.gh_remotes += [
-            (fork["full_name"],
-             fork["clone_url"],
-             fork["owner"]["login"])
-            for fork in forks
-        ]
+        forks = chain(forks, github.get_forks(base_remote))
 
-        self.view.window().show_quick_panel([remote[0] for remote in self.gh_remotes], self.on_select)
+        show_paginated_panel(
+            forks,
+            self.on_select,
+            limit=100,
+            format_item=self.format_item,
+            status_message="Getting forks...")
 
-    def on_select(self, idx):
-        if idx == -1:
+    def format_item(self, fork):
+        return (fork["full_name"], fork)
+
+    def on_select(self, fork):
+        if not fork:
             return
-        full_name, url, owner = self.gh_remotes[idx]
+
+        url = fork["clone_url"]
+        owner = fork["owner"]["login"]
         self.git("remote", "add", owner, url)
         sublime.status_message("Added remote '{}'.".format(owner))

--- a/github/commands/add_fork_as_remote.py
+++ b/github/commands/add_fork_as_remote.py
@@ -19,6 +19,7 @@ class GsAddForkAsRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemotes
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         base_remote = github.parse_remote(self.get_integrated_remote_url())
         base_repo_data = github.get_repo_data(base_remote)
         parent = None
@@ -38,7 +39,7 @@ class GsAddForkAsRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemotes
         show_paginated_panel(
             forks,
             self.on_select,
-            limit=100,
+            limit=savvy_settings.get("github_per_page_max", 100),
             format_item=self.format_item,
             status_message="Getting forks...")
 

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -81,13 +81,21 @@ class GsShowGithubContributorsCommand(TextCommand, GitCommand):
 
         contributors = github.get_contributors(remote)
 
-        if not contributors:
+        pp = show_paginated_panel(
+            contributors,
+            self.on_done,
+            format_item=self.format_item,
+            limit=100,
+            status_message="Getting contributors..."
+            )
+        if pp.is_empty():
+            sublime.status_message("No contributors found.")
+
+    def format_item(self, contributor):
+        return (contributor["login"], contributor)
+
+    def on_done(self, contributor):
+        if not contributor:
             return
 
-        self.menu_items = [contributor["login"] for contributor in contributors]
-        self.view.show_popup_menu(self.menu_items, self.on_done)
-
-    def on_done(self, selection_id):
-        if selection_id != -1:
-            selection = self.menu_items[selection_id]
-            self.view.run_command("gs_insert_text_at_cursor", {"text": selection})
+        self.view.run_command("gs_insert_text_at_cursor", {"text": contributor["login"]})

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -39,6 +39,7 @@ class GsShowGithubIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemote
         sublime.set_timeout_async(lambda: self.run_async(nondefault_repo))
 
     def run_async(self, nondefault_repo):
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         remote = github.parse_remote(self.get_integrated_remote_url())
 
         if nondefault_repo:
@@ -56,7 +57,7 @@ class GsShowGithubIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemote
             issues,
             self.on_done,
             format_item=self.format_item,
-            limit=100,
+            limit=savvy_settings.get("github_per_page_max", 100),
             status_message="Getting issues..."
             )
         if pp.is_empty():
@@ -96,6 +97,7 @@ class GsShowGithubContributorsCommand(TextCommand, GitCommand):
         sublime.set_timeout_async(lambda: self.run_async())
 
     def run_async(self):
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         default_remote_name, default_remote = self.get_remotes().popitem(last=False)
         remote = github.parse_remote(default_remote)
 
@@ -105,7 +107,7 @@ class GsShowGithubContributorsCommand(TextCommand, GitCommand):
             contributors,
             self.on_done,
             format_item=self.format_item,
-            limit=100,
+            limit=savvy_settings.get("github_per_page_max", 100),
             status_message="Getting contributors..."
             )
         if pp.is_empty():

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -25,13 +25,14 @@ class GsPullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixi
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         base_remote = github.parse_remote(self.get_integrated_remote_url())
         self.pull_requests = github.get_pull_requests(base_remote)
 
         pp = show_paginated_panel(
             self.pull_requests,
             self.on_select_pr,
-            limit=100,
+            limit=savvy_settings.get("github_per_page_max", 100),
             format_item=self.format_item,
             status_message="Getting pull requests..."
             )

--- a/github/github.py
+++ b/github/github.py
@@ -12,6 +12,8 @@ import sublime
 from ..common import interwebs, util
 from ..core.exceptions import FailedGithubRequest
 
+GITHUB_PER_PAGE_MAX = 100
+
 GitHubRepo = namedtuple("GitHubRepo", ("url", "fqdn", "owner", "repo", "token"))
 
 
@@ -157,7 +159,7 @@ def iteratively_query_github(api_url_template, github_repo):
         repo=github_repo.repo
     )
 
-    path = path + "?per_page=100"
+    path = path + "?per_page={:d}".format(GITHUB_PER_PAGE_MAX)
 
     auth = (github_repo.token, "x-oauth-basic") if github_repo.token else None
 


### PR DESCRIPTION
Github API has a limit of 30 items per request (can be changed to 100), this PR uses `show_paginated_panel` to show all the items in various commands.

1. `github: add fork as remote`, fix #528

![aug-14-2017 22-28-52](https://user-images.githubusercontent.com/1690993/29299906-0054b730-8140-11e7-8fcd-f3d7f0943eb4.gif)


2. `github: review pull request`

![aug-14-2017 22-30-27](https://user-images.githubusercontent.com/1690993/29299941-33f0b7ce-8140-11e7-95d8-6da4b283964c.gif)

3. contributors and issues completion

![aug-14-2017 22-35-03](https://user-images.githubusercontent.com/1690993/29300032-d929b01a-8140-11e7-80e4-0e7473fd1a77.gif)



<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

