### PR TITLE
Enhancement: offer push to remote rather than configuring remote

### DIFF
--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -8,9 +8,11 @@ from .. import github
 from .. import git_mixins
 from ...common import interwebs
 from ...common import util
+from ...core.commands.push import GsPushToBranchNameCommand
 
-SET_UPSTREAM_PROMPT = ("You have not set an upstream for the active branch.  "
-                       "Would you like to set one?")
+
+PUSH_PROMPT = ("You have not set an upstream for the active branch.  "
+               "Would you like to push to a remote?")
 
 
 class GsPullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):
@@ -155,19 +157,11 @@ class GsCreatePullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemot
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        if savvy_settings.get("prompt_for_tracking_branch") and not self.get_upstream_for_active_branch():
-            if sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT):
-                self.remotes = list(self.get_remotes().keys())
-
-                if not self.remotes:
-                    self.view.window().show_quick_panel(["There are no remotes available."], None)
-                else:
-                    self.view.window().show_quick_panel(
-                        self.remotes,
-                        self.on_select_remote,
-                        flags=sublime.MONOSPACE_FONT
-                        )
+        if not self.get_upstream_for_active_branch():
+            if sublime.ok_cancel_dialog(PUSH_PROMPT):
+                self.view.window().run_command(
+                    "gs_push_and_create_pull_request",
+                    {"set_upstream": True})
 
         else:
             remote_branch = self.get_active_remote_branch()
@@ -199,46 +193,9 @@ class GsCreatePullRequestCommand(TextCommand, GitCommand, git_mixins.GithubRemot
             branch
         ))
 
-    def on_select_remote(self, remote_index):
-        """
-        After the user selects a remote, display a panel of branches that are
-        present on that remote, then proceed to `on_select_branch`.
-        """
-        # If the user pressed `esc` or otherwise cancelled.
-        if remote_index == -1:
-            return
 
-        self.selected_remote = self.remotes[remote_index]
-        self.branches_on_selected_remote = self.list_remote_branches(self.selected_remote)
+class GsPushAndCreatePullRequestCommand(GsPushToBranchNameCommand):
 
-        self.current_local_branch = self.get_current_branch_name()
-
-        try:
-            pre_selected_index = self.branches_on_selected_remote.index(
-                self.selected_remote + "/" + self.current_local_branch)
-        except ValueError:
-            pre_selected_index = 0
-
-        self.view.window().show_quick_panel(
-            self.branches_on_selected_remote,
-            self.on_select_branch,
-            flags=sublime.MONOSPACE_FONT,
-            selected_index=pre_selected_index
-        )
-
-    def on_select_branch(self, branch_index):
-        """
-        Determine the actual branch name of the user's selection, and proceed
-        to `do_pull`.
-        """
-        # If the user pressed `esc` or otherwise cancelled.
-        if branch_index == -1:
-            return
-        selected_remote_branch = self.branches_on_selected_remote[branch_index].split("/", 1)[1]
-        remote_ref = self.selected_remote + "/" + selected_remote_branch
-
-        self.current_local_branch = self.get_current_branch_name()
-
-        self.git("branch", "-u", remote_ref, self.current_local_branch)
-
-        sublime.set_timeout_async(self.run_async, 0)
+    def do_push(self, *args, **kwargs):
+        super().do_push(*args, **kwargs)
+        self.window.active_view().run_command("gs_create_pull_request")

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -131,8 +131,6 @@ class GsPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMi
 
     def view_diff_for_pr(self):
         response = interwebs.get_url(self.pr["diff_url"])
-        print("getting", self.pr["diff_url"])
-        print(repr(response.payload.decode("utf-8")))
 
         diff_view = util.view.get_scratch_view(self, "pr_diff", read_only=True)
         diff_view.set_name("PR #{}".format(self.pr["number"]))


### PR DESCRIPTION
Close #738 
when creating PR without tracking remote, prompt to push to remote instead of asking to configure remote tracking branch.

PS: this PR is created by this feature.
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

