### PR TITLE
[WIP] offer "push to remote" while open file on remote

### DIFF
--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -106,11 +106,14 @@ class GsPushToBranchNameCommand(WindowCommand, PushBase):
     Prompt for remote and remote branch name, then push.
     """
 
-    def run(self, branch_name=None, set_upstream=False, force=False):
+    def run(self, branch_name=None, remote=None, set_upstream=False, force=False):
         self.branch_name = branch_name
         self.set_upstream = set_upstream
         self.force = force
-        sublime.set_timeout_async(self.run_async)
+        if remote:
+            sublime.set_timeout_async(self.on_remote_selection(remote))
+        else:
+            sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
         show_remote_panel(self.on_remote_selection)

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -89,3 +89,13 @@ class BranchesMixin():
         for branch in self.get_branches():
             if not branch.remote and branch.name == branch_name:
                 return branch
+
+    def branches_contain_commit(self, commit_hash, local_only=True, remote_only=False):
+        branches = self.git(
+            "branch",
+            "-a" if not local_only and not remote_only else None,
+            "-r" if remote_only else None,
+            "--contains",
+            commit_hash
+            ).strip().split("\n")
+        return [branch.strip() for branch in branches]

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -1,6 +1,7 @@
 import itertools
 import sublime
 from ...common import util
+from ..git_command import GitCommand
 
 
 class PanelActionMixin(object):
@@ -110,6 +111,182 @@ class PanelCommandMixin(PanelActionMixin):
         """
         args, kwargs = super().get_arguments(selected_action)
         return ((selected_action[0], ) + args), kwargs
+
+
+def show_remote_panel(on_done, show_all=False, selected_remote=None):
+    """
+    Show a quick panel with remotes. The callback `on_done(remote)` will
+    be called when a remote is selected. If the panel is cancelled, `None`
+    will be passed to `on_done`.
+
+    on_done: a callable
+    show_all: whether the option "All remotes" should be shown. `True` will
+                be passed to `on_done` if the all remotes option is selected.
+    """
+    rp = RemotePanel(on_done, show_all, selected_remote)
+    rp.show()
+    return rp
+
+
+class RemotePanel(GitCommand):
+
+    def __init__(self, on_done, show_all=False, selected_remote=None):
+        self.window = sublime.active_window()
+        self.on_done = on_done
+        self.selected_remote = selected_remote
+        self.show_all = show_all
+
+    def show(self):
+        self.remotes = list(self.get_remotes().keys())
+
+        if not self.remotes:
+            self.window.show_quick_panel(["There are no remotes available."], None)
+            return
+
+        # should we proceed directly if len(self.remotes) == 1 !?
+        # GsRemoteRemoveCommand may not work well if we proceed directly
+
+        if self.show_all and len(self.remotes) > 1:
+            self.remotes.insert(0, "All remotes.")
+
+        if self.last_remote_used in self.remotes:
+            pre_selected_index = self.remotes.index(self.last_remote_used)
+        else:
+            pre_selected_index = 0
+
+        self.window.show_quick_panel(
+            self.remotes,
+            self.on_remote_selection,
+            flags=sublime.MONOSPACE_FONT,
+            selected_index=pre_selected_index
+        )
+
+    def on_remote_selection(self, index):
+        if index == -1:
+            self.on_done(None)
+        elif self.show_all and len(self.remotes) > 1 and index == 0:
+            self.on_done(True)
+        else:
+            self.remote = self.remotes[index]
+            self.last_remote_used = self.remote
+            self.on_done(self.remote)
+
+
+def show_branch_panel(
+        on_done,
+        local_branches_only=False,
+        remote_branches_only=False,
+        ignore_current_branch=False,
+        ask_remote_first=False,
+        local_branch=None,
+        selected_branch=None):
+    """
+    Show a quick panel with branches. The callback `on_done(branch)` will
+    be called when a branch is selected. If the panel is cancelled, `None`
+    will be passed to `on_done`.
+
+    on_done: a callable
+    ask_remote_first: whether remote should be asked before the branch panel
+            if `False`. the options will be in forms of `remote/branch`
+    selected_branch: if `ask_remote_first`, the selected branch will be
+            `{remote}/{selected_branch}`
+    """
+    bp = BranchPanel(
+        on_done,
+        local_branches_only,
+        remote_branches_only,
+        ignore_current_branch,
+        ask_remote_first,
+        selected_branch)
+    bp.show()
+    return bp
+
+
+class BranchPanel(GitCommand):
+
+    def __init__(
+            self, on_done, local_branches_only=False, remote_branches_only=False,
+            ignore_current_branch=False, ask_remote_first=False, selected_branch=None):
+        self.window = sublime.active_window()
+        self.on_done = on_done
+        self.local_branches_only = local_branches_only
+        self.remote_branches_only = True if ask_remote_first else remote_branches_only
+        self.ignore_current_branch = ignore_current_branch
+        self.ask_remote_first = ask_remote_first
+        self.selected_branch = selected_branch
+
+    def show(self):
+        if self.ask_remote_first:
+            show_remote_panel(
+                lambda remote: sublime.set_timeout_async(
+                    lambda: self.on_remote_selection(remote), 100))
+        else:
+            self.select_branch(remote=None)
+
+    def on_remote_selection(self, remote):
+        if not remote:
+            return
+
+        self.select_branch(remote)
+
+    def select_branch(self, remote=None):
+
+        if self.local_branches_only:
+            self.all_branches = [b.name_with_remote for b in self.get_branches() if not b.remote]
+        elif self.remote_branches_only:
+            self.all_branches = [b.name_with_remote for b in self.get_branches() if b.remote]
+        else:
+            self.all_branches = [b.name_with_remote for b in self.get_branches()]
+
+        if self.ignore_current_branch:
+            current_branch = self.get_current_branch_name()
+            self.all_branches = [b for b in self.all_branches if b != current_branch]
+
+        if remote:
+            self.all_branches = [b for b in self.all_branches if b.startswith(remote + "/")]
+
+        if not self.all_branches:
+            self.window.show_quick_panel(["There are no branches available."], None)
+            return
+
+        self.window.show_quick_panel(
+            self.all_branches,
+            self.on_branch_selection,
+            flags=sublime.MONOSPACE_FONT,
+            selected_index=self.get_pre_selected_branch_index(remote)
+        )
+
+    def get_pre_selected_branch_index(self, remote):
+        pre_selected_index = None
+        if self.selected_branch is None:
+            selected_branch = self.get_current_branch_name()
+        else:
+            selected_branch = self.selected_branch
+
+        if pre_selected_index is None:
+            if self.ask_remote_first:
+                pre_selected_remote_branch = "{}/{}".format(remote, selected_branch)
+                if pre_selected_remote_branch in self.all_branches:
+                    pre_selected_index = self.all_branches.index(pre_selected_remote_branch)
+            elif self.selected_branch in self.all_branches:
+                    pre_selected_index = self.all_branches.index(selected_branch)
+
+        if pre_selected_index is None:
+            if selected_branch is not None and selected_branch in self.all_branches:
+                pre_selected_index = self.all_branches.index(selected_branch)
+
+        if pre_selected_index is None:
+            pre_selected_index = 0
+
+        return pre_selected_index
+
+    def on_branch_selection(self, index):
+        if index == -1:
+            self.branch = None
+        else:
+            self.branch = self.all_branches[index]
+
+        self.on_done(self.branch)
 
 
 def show_paginated_panel(items, on_done, flags=None, selected_index=None, on_highlight=None,

--- a/github/commands/open_on_remote.py
+++ b/github/commands/open_on_remote.py
@@ -7,6 +7,7 @@ from ..github import open_repo
 from ..github import open_issues
 
 from .. import git_mixins
+from ...core.ui_mixins.quick_panel import show_remote_panel
 
 
 class GsOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemotesMixin):
@@ -38,27 +39,12 @@ class GsOpenFileOnRemoteCommand(TextCommand, GitCommand, git_mixins.GithubRemote
         if remote:
             self.open_file_on_remote(remote)
         else:
-            try:
-                pre_selected_index = self.remote_keys.index(self.last_remote_used)
-            except ValueError:
-                pre_selected_index = 0
-
-            self.view.window().show_quick_panel(
-                self.remote_keys,
-                self.on_select_remote,
-                flags=sublime.MONOSPACE_FONT,
-                selected_index=pre_selected_index
-            )
-
-    def on_select_remote(self, index):
-        if index == -1:
-            return
-
-        remote = self.remote_keys[index]
-        self.last_remote_used = remote
-        self.open_file_on_remote(remote)
+            show_remote_panel(self.open_file_on_remote)
 
     def open_file_on_remote(self, remote):
+        if not remote:
+            return
+
         fpath = self.fpath
         if isinstance(fpath, str):
             fpath = [fpath]
@@ -111,23 +97,11 @@ class GsOpenGithubRepoCommand(TextCommand, GitCommand, git_mixins.GithubRemotesM
         if remote:
             open_repo(self.remotes[remote])
         else:
-            try:
-                pre_selected_index = self.remote_keys.index(self.last_remote_used)
-            except ValueError:
-                pre_selected_index = 0
+            show_remote_panel(self.on_remote_selection)
 
-            self.view.window().show_quick_panel(
-                self.remote_keys,
-                self.on_select_remote,
-                flags=sublime.MONOSPACE_FONT,
-                selected_index=pre_selected_index
-            )
-
-    def on_select_remote(self, index):
-        if index == -1:
+    def on_remote_selection(self, remote):
+        if not remote:
             return
-        remote = self.remote_keys[index]
-        self.last_remote_used = remote
         open_repo(self.remotes[remote])
 
 


### PR DESCRIPTION
When doing `github: open file on remote`, if the current branch is ahead of remote, the opened url would be invalid.

I was originally thinking to use the newest commit locally known, but I quickly discovered that a local branch doesn't necessarily have a remote tracking branch. So instead, we offer "push to remote" if the current branch commit cannot be found in the remotes.

Any suggestions?

This PR contains 3 commits from #713 

close #723
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only
