### PR TITLE
Enhancement: do not open panel when window doesn't exist

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -101,6 +101,9 @@ class GitCommand(StatusMixin,
         try:
             if not working_dir:
                 working_dir = self.repo_path
+        except RuntimeError as e:
+            # do not show panel when the window does not exist
+            raise GitSavvyError(e, show_panel=False)
         except Exception as e:
             # offer initialization when "Not a git repository" is thrown from self.repo_path
             if type(e) == ValueError and e.args and "Not a git repository" in e.args[0]:
@@ -284,10 +287,13 @@ class GitCommand(StatusMixin,
             repo_path = self.find_repo_path()
             if not repo_path:
                 window = view.window()
-                if window and window.folders():
-                    raise ValueError("Not a git repository.")
+                if window:
+                    if window.folders():
+                        raise ValueError("Not a git repository.")
+                    else:
+                        raise ValueError("Unable to determine Git repo path.")
                 else:
-                    raise ValueError("Unable to determine Git repo path.")
+                    raise RuntimeError("Window does not exist.")
 
             if view:
                 file_name = view.file_name()


### PR DESCRIPTION
Another enhancement of issue #726.

Throw RuntimeError If the current view is detached, it will result in a `GitSavvyError` without showing panel.

cc: @asfaltboy, hope this would be the final fix.

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

