### PR TITLE
Enhancement: more robust to open file on remote

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -89,3 +89,16 @@ class BranchesMixin():
         for branch in self.get_branches():
             if not branch.remote and branch.name == branch_name:
                 return branch
+
+    def branches_containing_commit(self, commit_hash, local_only=True, remote_only=False):
+        """
+        Return a list of branches which contain a particular commit.
+        """
+        branches = self.git(
+            "branch",
+            "-a" if not local_only and not remote_only else None,
+            "-r" if remote_only else None,
+            "--contains",
+            commit_hash
+            ).strip().split("\n")
+        return [branch.strip() for branch in branches]

--- a/core/git_mixins/remotes.py
+++ b/core/git_mixins/remotes.py
@@ -83,3 +83,12 @@ class RemotesMixin():
         # Kind of funky, but does the job
         _split_url = re.split('/|:', input_url)
         return _split_url[-2] if len(_split_url) >= 2 else ''
+
+    def remotes_containing_commit(self, commit_hash):
+        """
+        Return a list of remotes which contain a particular commit.
+        """
+        return list(set([
+            branch.split("/")[0]
+            for branch in self.branches_containing_commit(commit_hash, remote_only=True)
+        ]))


### PR DESCRIPTION
close #723 

Open file at merge base if the remote branch doesn't contain the opening commit.


To test this PR, checkout a branch which has a tracking remote. Add a new commit and open the file at remote. It should prompt a message asking to open the file 1 commit earlier.


<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

