### PR TITLE
Other: refactor log_git and add log_process

### DIFF
--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -41,25 +41,34 @@ def add_to_log(obj):
         _log.append(obj)
 
 
+def make_log_message(_type, **kwargs):
+    """
+    Create a log message dictionary to be stored in JSON formatted debug log
+    """
+    message = {"type": _type}
+    message.update(kwargs)
+
+    return message
+
+
 def log_git(command, stdin, stdout, stderr, seconds):
-    message = {
-        "type": "git",
-        "command": command,
-        "stdin": stdin,
-        "stdout": stdout,
-        "stderr": stderr,
-        "seconds": seconds
-        }
+    """ Add git command details to debug log """
+    message = make_log_message(
+        'git', command=command, stdin=stdin, stdout=stdout, stderr=stderr,
+        seconds=seconds
+        )
+    for field in ['stdin', 'stdout', 'stderr']:
+        if isinstance(field, bytes):  # decode standard I/O bytes
+            message[field] = try_to_decode(locals()[field], field)
+    add_to_log(message)
 
-    if stdin.__class__ == bytes:
-        message["stdin"] = try_to_decode(stdin, "stdin")
 
-    if stdout.__class__ == bytes:
-        message["stdout"] = try_to_decode(stdout, "stdout")
-
-    if stderr.__class__ == bytes:
-        message["stderr"] = try_to_decode(stderr, "stderr")
-
+def log_process(command, cwd, env, startupinfo):
+    """ Add Popen call details to debug log """
+    message = make_log_message(
+        'subprocess.Popen', command=command, cwd=cwd, env=env,
+        startupinfo=startupinfo
+        )
     add_to_log(message)
 
 

--- a/core/git_mixins/merge.py
+++ b/core/git_mixins/merge.py
@@ -35,11 +35,12 @@ class MergeMixin():
         base_content, ours_content, theirs_content = versioned_content
 
         temp_dir = tempfile.mkdtemp()
+        repo_path = self.repo_path
         base_path = os.path.join(temp_dir, "base")
         ours_path = os.path.join(temp_dir, "ours")
         theirs_path = os.path.join(temp_dir, "theirs")
         backup_path = os.path.join(temp_dir, "backup")
-        merge_path = os.path.join(self.repo_path, fpath)
+        merge_path = os.path.join(repo_path, fpath)
 
         merge_cmd = merge_cmd_tmpl.replace("$REMOTE", theirs_path)
         merge_cmd = merge_cmd.replace("$BASE", base_path)
@@ -61,9 +62,13 @@ class MergeMixin():
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
+            util.debug.log_process(
+                merge_cmd_args, repo_path, os.environ, startupinfo
+                )
+
             p = subprocess.Popen(
                 merge_cmd_args,
-                cwd=self.repo_path,
+                cwd=repo_path,
                 env=os.environ,
                 startupinfo=startupinfo
                 )


### PR DESCRIPTION
Might be useful for logging `subprocess.Popen` commands, other than git, in the debug log. Currently logs launch of `mergetool` which is the only other `Popen` call we have.

Related to #681
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [x] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

