### PR TITLE
Other: release 2.16.2

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -22,5 +22,5 @@
     "2.14.0": "messages/2.14.0.txt",
     "2.14.1": "messages/2.14.1.txt",
     "2.14.2": "messages/2.14.2.txt",
-    "2.15.0": "messages/2.15.0.txt",
+    "2.16.2": "messages/2.16.2.txt"
 }

--- a/messages/2.16.2.txt
+++ b/messages/2.16.2.txt
@@ -1,6 +1,6 @@
 Changes since 2.14.2:
 
-  Braking change:
+  Breaking changes:
     - in branch dashboard, when checking out remote branch as local use `b` instead of `o`.
 
   Feature:


### PR DESCRIPTION
There was a typo in `messages.json` so the release was never announced. Instead of 2.15.0, we have bumped the version to 2.16.0.

Actually, I believe a lot of users have upgrade to 2.16.1 (the most recent release), shall we tag 2.16.2?


<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only
