### PR TITLE
Enhancement: don't show "following output" when stderr is empty

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -158,9 +158,12 @@ class GitCommand(StatusMixin,
                 sublime.set_timeout_async(
                     lambda: sublime.active_window().run_command("gs_setup_user"))
 
-            raise GitSavvyError("`{}` failed with following output:\n{}\n{}".format(
-                command_str, stdout, stderr
-            ))
+            if stdout or stderr:
+                raise GitSavvyError("`{}` failed with following output:\n{}\n{}".format(
+                    command_str, stdout, stderr
+                ))
+            else:
+                raise GitSavvyError("`{}` failed.".format(command_str))
 
         if show_panel:
             if savvy_settings.get("show_input_in_output"):


### PR DESCRIPTION
Address the issue in #761.

As @stoivo  and I discussed before, we should merge it in a week to allow users to read the release note of 2.16.2.



<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [x] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

