### PR TITLE
Internal: maintainerd - don't enforce empty line

### DIFF
--- a/.maintainerd
+++ b/.maintainerd
@@ -25,7 +25,7 @@ commit:
     mustMatch: !!js/regexp /^(Fix|Enhancement|Feature|Internal|Other|Release):\s.*/
     mustNotMatch: !!js/regexp /^fixup!/
   message:
-    enforceEmptySecondLine: true
+    enforceEmptySecondLine: false
     linesMustHaveLengthBetween: [0, 72]
 issue:
   onLabelAdded:


### PR DESCRIPTION
Temp. workaround due to  wrongly reported commit structure issue as in divmain/maintainerd#1

I dug in the code and it seems it's the right thing to toggle, as in:
https://github.com/divmain/maintainerd/blob/master/event-handlers/pull-request/handle-action/synchronize.js#L36-L57
<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [ ] <!-- semver --> documentation only

