### PR TITLE
Internal: add ISSUE_TEMPLATE.md and PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+If you encounter a bug, please check for an open issue that already captures the problem you've run into.  If it doesn't exist yet, create it!
+
+Please include the following information when filing a bug:
+
+- Sublime Text version number
+- Git version number
+- OS type and version
+- Console error output
+- A description of the problem.
+- Steps to reproduce, if possible
+- If the bug is caused by a failing command, [include a debug log](docs/debug.md#providing-a-debug-log).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Hotfixes should be submitted to `master` branch and the changes are published
+automatically whenever a pull request is merged.  As part of the PR process,
+you will be asked to provide the information necessary to make that happen.
+
+Pull requests on new features should be submitted to `dev` branch and will be
+regularly merged into `master` after evaluations over an extended period of
+time.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ Some other things to remember:
 - Include docstrings for all classes and functions, unless functionality is obvious at a glance.
 - Include descriptions for issues and PRs.
 
-I'm busy and travel sometimes for work - so if I don't respond immediately, please be patient.  I promise to reply!
 
 ## Commit message structure
 
@@ -50,8 +49,6 @@ Please include the following information when filing a bug:
 - Steps to reproduce, if possible
 - If the bug is caused by a failing command, [include a debug log](docs/debug.md#providing-a-debug-log).
 
-If you're interested in tackling a bug, please say so and I can assign it to you.
-
 
 # Documentation
 
@@ -64,4 +61,10 @@ Check the implementation details of the [tests](docs/testing.md).
 
 # Publishing
 
-All changes are published automatically whenever a pull request is merged.  As part of the PR process, you will be asked to provide the information necessary to make that happen.
+Hotfixes should be submitted to `master` branch and the changes are published
+automatically whenever a pull request is merged.  As part of the PR process,
+you will be asked to provide the information necessary to make that happen.
+
+Pull requests on new features should be submitted to `dev` branch and will be
+regularly merged into `master` after evaluations over an extended period of
+time.


### PR DESCRIPTION
I accidentally removed my origin repo.

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [x] <!-- semver --> documentation only
