### PR TITLE
Enhancement: Improvements to fetch quick panel

### DIFF
--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -17,7 +17,7 @@ class GsFetchCommand(WindowCommand, GitCommand):
         if remote:
             return self.do_fetch(remote)
 
-        show_remote_panel(self.on_remote_selection, show_option_all=True)
+        show_remote_panel(self.on_remote_selection, show_option_all=True, allow_direct=True)
 
     def on_remote_selection(self, remote):
         if not remote:

--- a/docs/remotes.md
+++ b/docs/remotes.md
@@ -4,7 +4,7 @@ GitSavvy provides a few mechanisms for interact with remotes.
 
 ## `git: fetch`
 
-This updates the local history of remote branches, and downloads all commit objects referenced in that history.  When running this command from the palette, you will prompted to indicate the remote from which you'd like to fetch.
+This updates the local history of remote branches, and downloads all commit objects referenced in that history. If the repository has multiple remotes you will prompted to indicate the remote from which you'd like to fetch, when running this command from the palette.
 
 ## `git: checkout remote branch as local`
 


### PR DESCRIPTION
This PR addresses a couple annoyances I've noticed with `GsFetchCommand`:
- The quick panel prompts you to select a remote even when the repository only has a single remote, which feels redundant.
- The quick panel can remember the last choice you selected if it's an individual remote, but can't remember if your last choice was `All remotes`.

### Changes:
- If there is only one remote, fetch from that immediately without requiring a second user interaction. To support this without impacting other remote commands (e.g. `GsRemoteRemoveCommand`) I added an `allow_direct` keyword argument to `show_remote_panel`.
- If there are multiple remotes, make the preselected choice "All remotes." if `GitCommand.last_remote_used` hasn't been set.
- Allow the quick panel to remember `All remotes.` as the previous selection.

Closes #601

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [x] <!-- semver --> documentation only

