### PR TITLE
turn off semver of maintainerd

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-Hotfixes should be submitted to `master` branch and the changes are published
-automatically whenever a pull request is merged.  As part of the PR process,
+Hotfixes should be submitted to `master` branch. As part of the PR process,
 you will be asked to provide the information necessary to make that happen.
 
 Pull requests on new features should be submitted to `dev` branch and will be

--- a/.maintainerd
+++ b/.maintainerd
@@ -16,7 +16,7 @@ pullRequest:
       default: false
       required: true
   semver:
-    enabled: true
+    enabled: false
     # Not yet implemented:
     autodetect: true
 commit:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,7 @@ Check the implementation details of the [tests](docs/testing.md).
 
 # Publishing
 
-Hotfixes should be submitted to `master` branch and the changes are published
-automatically whenever a pull request is merged.  As part of the PR process,
+Hotfixes should be submitted to `master` branch. As part of the PR process,
 you will be asked to provide the information necessary to make that happen.
 
 Pull requests on new features should be submitted to `dev` branch and will be


### PR DESCRIPTION
maintainerd semver feature is confusing for a PR targetting a branch other than master

<!-- maintainerd: DO NOT REMOVE -->

-----

The maintainers of this repo require that all pull request submitters agree and adhere to the following:

- [x] <!-- checklist item; required -->I have read and agree to the [contribution guidelines](https://github.com/divmain/GitSavvy/blob/master/CONTRIBUTING.md).
 _(required)_
- [x] <!-- checklist item; required -->All related documentation has been updated to reflect the changes made. _(required)_
- [x] <!-- checklist item; required -->My commit messages are cleaned up and ready to merge. _(required)_

The maintainers of this repository require you to select the semantic version type that
the changes in this pull request represent.  Please select one of the following:
- [ ] <!-- semver --> major
- [ ] <!-- semver --> minor
- [ ] <!-- semver --> patch
- [x] <!-- semver --> documentation only

