### PR TITLE
set the default for max_items_in_tags_dashboard to -1

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -166,7 +166,7 @@
     /*
         Limit the number of tags listed in the tags dashboard.
     */
-    // "max_items_in_tags_dashboard": 10
+    "max_items_in_tags_dashboard": -1,
 
     /*
         When set to `true`, GitSavvy will offer to set the upstream on `git: push`


### PR DESCRIPTION
so that PackageDev will be able to pick up the setting
-1 is in effect of selecting all tags.
