### PR TITLE
do not pass kwargs to Exception

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -4,7 +4,7 @@ from ..common import util
 
 class GitSavvyError(Exception):
     def __init__(self, msg, *args, **kwargs):
-        super(GitSavvyError, self).__init__(msg, *args, **kwargs)
+        super(GitSavvyError, self).__init__(msg, *args)
         if msg:
             if kwargs.get('show_panel', True):
                 util.log.panel(msg)


### PR DESCRIPTION
It is to handle the issue `GitSavvyError does not take keyword arguments` in [this](https://github.com/divmain/GitSavvy/issues/772#issuecomment-342436635) comment.


Note: it does NOT fix issue 772