### PR TITLE
Fix: switch back to `open`

### DIFF
--- a/core/git_mixins/rewrite.py
+++ b/core/git_mixins/rewrite.py
@@ -209,7 +209,7 @@ class RewriteMixin():
 
     def rebase_orig_head(self):
         path = os.path.join(self._rebase_dir, "orig-head")
-        with util.file.safe_open(path, "r") as f:
+        with open(path, "r") as f:
             return f.read().strip()
 
     def rebase_conflict_at(self):
@@ -217,17 +217,17 @@ class RewriteMixin():
             path = os.path.join(self._rebase_merge_dir, "current-commit")
         else:
             path = os.path.join(self._rebase_apply_dir, "original-commit")
-        with util.file.safe_open(path, "r") as f:
+        with open(path, "r") as f:
             return f.read().strip()
 
     def rebase_branch_name(self):
         path = os.path.join(self._rebase_dir, "head-name")
-        with util.file.safe_open(path, "r") as f:
+        with open(path, "r") as f:
             return f.read().strip().replace("refs/heads/", "")
 
     def rebase_onto_commit(self):
         path = os.path.join(self._rebase_dir, "onto")
-        with util.file.safe_open(path, "r") as f:
+        with open(path, "r") as f:
             return f.read().strip()
 
     def rebase_rewritten(self):
@@ -237,7 +237,7 @@ class RewriteMixin():
                 return dict()
             entries = []
             for sha in os.listdir(path):
-                with util.file.safe_open(os.path.join(path, sha), "r") as f:
+                with open(os.path.join(path, sha), "r") as f:
                     newsha = f.read().strip()
                     if newsha:
                         entries.append([sha, newsha])
@@ -246,7 +246,7 @@ class RewriteMixin():
             path = os.path.join(self._rebase_apply_dir, "rewritten")
             if not os.path.exists(path):
                 return dict()
-            with util.file.safe_open(path, "r") as f:
+            with open(path, "r") as f:
                 entries = f.read().strip().split("\n")
                 return [entry.split(" ") for entry in entries]
         else:
@@ -255,7 +255,7 @@ class RewriteMixin():
                 return dict()
             entries = []
             for sha in os.listdir(path):
-                with util.file.safe_open(os.path.join(path, sha), "r") as f:
+                with open(os.path.join(path, sha), "r") as f:
                     newsha = f.read().strip()
                     if newsha:
                         entries.append([sha, newsha])
@@ -265,5 +265,5 @@ class RewriteMixin():
         path = os.path.join(self._rebase_replay_dir, "rewritten")
         if not os.path.exists(path):
             os.makedirs(path)
-        with util.file.safe_open(os.path.join(path, old_hash), "w") as f:
+        with open(os.path.join(path, old_hash), "w") as f:
             f.write(new_hash)


### PR DESCRIPTION
fix #799, as these files are not user-created files
