### PR TITLE
Fix: ignoring file was not working

### DIFF
--- a/core/commands/ignore.py
+++ b/core/commands/ignore.py
@@ -18,9 +18,9 @@ class GsIgnoreCommand(WindowCommand, GitCommand):
     at the Git repo's root.
     """
 
-    def run(self, file_path_or_pattern):
+    def run(self, file_path_or_pattern=None):
         if not file_path_or_pattern:
-            file_path_or_pattern = self.file_path_or_pattern
+            file_path_or_pattern = self.file_path
 
         self.add_ignore(os.path.join("/", file_path_or_pattern))
         sublime.status_message("Ignored file `{}`.".format(file_path_or_pattern))

--- a/core/git_mixins/ignore.py
+++ b/core/git_mixins/ignore.py
@@ -16,10 +16,8 @@ class IgnoreMixin():
         if not linesep:
             # Use native line ending on Windows only when `autocrlf` is set to `true`.
             if os.name == "nt":
-                try:
-                    autocrlf = self.git("config", "--global", "core.autocrlf").strip() == "true"
-                except Exception:
-                    autocrlf = False
+                autocrlf = self.git("config", "--global", "core.autocrlf",
+                                    throw_on_stderr=False).strip() == "true"
                 linesep = os.linesep if autocrlf else "\n"
             else:
                 linesep = os.linesep

--- a/core/git_mixins/ignore.py
+++ b/core/git_mixins/ignore.py
@@ -16,7 +16,10 @@ class IgnoreMixin():
         if not linesep:
             # Use native line ending on Windows only when `autocrlf` is set to `true`.
             if os.name == "nt":
-                autocrlf = self.git("config", "--global", "core.autocrlf").strip() == "true"
+                try:
+                    autocrlf = self.git("config", "--global", "core.autocrlf").strip() == "true"
+                except Exception:
+                    autocrlf = False
                 linesep = os.linesep if autocrlf else "\n"
             else:
                 linesep = os.linesep


### PR DESCRIPTION
close #781

- set default ignore file as current file
- catch the error when running `config --global core.autocrlf` when the setting was not set.