### PR TITLE
Fix: Use correct argument for blame all commits

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -107,7 +107,7 @@ class GsBlameRefreshCommand(BlameMixin, TextCommand, GitCommand):
     _detect_move_or_copy_dict = {
         "file": "-M",
         "commit": "-C",
-        "all_commits": "-CC"
+        "all_commits": "-CCC"
     }
 
     def run(self, edit):


### PR DESCRIPTION
For `blame` to detect moved or copied lines in all commits, the command line argument is `-CCC`, this was changed to `-CC` in the blame refactor.

- `-C` detects in the modifying commit
- `-CC` detects in the modifying commit AND the commit that created the file
- `-CCC` detects moved or copied lines in all commits

See: https://git-scm.com/docs/git-blame#git-blame--Cltnumgt
