### PR TITLE
Log githook progress

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -110,6 +110,14 @@
     "live_panel_output": false,
 
     /*
+        Command will exit if on the timeout if the timeout reached.
+        You may want to increase this if you have a slow disk or a very
+        large repository. If you think there is something GitSavvy can do
+        to prevent this long running git command, open an issue.
+    */
+    "live_panel_output_timeout": 10000,
+
+    /*
         Use the Sublime configured syntax for COMMIT_EDITMSG rather than
         the custom bundled syntax that comes with GitSavvy.
     */

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -139,6 +139,11 @@
     "show_input_in_output": true,
 
     /*
+        Change this to `true` to print the stdin in the panel output.
+     */
+    "show_stdin_in_output": false,
+
+    /*
         Change this to `false` to suppress Git status in ST3 status bar.
      */
     "git_status_in_status_bar": true,

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -104,6 +104,12 @@
     "close_panel_for": [],
 
     /*
+        Whether git and githook output is logged live
+        If false, results are shown after execution.
+    */
+    "live_panel_output": false,
+
+    /*
         Use the Sublime configured syntax for COMMIT_EDITMSG rather than
         the custom bundled syntax that comes with GitSavvy.
     */

--- a/common/commands/log.py
+++ b/common/commands/log.py
@@ -19,3 +19,22 @@ class GsDisplayPanelCommand(TextCommand):
         panel_view.set_read_only(True)
         panel_view.show(0)
         self.view.window().run_command("show_panel", {"panel": "output.{}".format(PANEL_NAME)})
+
+
+class GsAppendPanelCommand(TextCommand):
+
+    """
+    Given a `msg` string, find a transient text panel at the bottom of the
+    active window, and append the `msg` contents there.
+    """
+
+    def run(self, edit, msg=""):
+        panel_view = self.view.window().find_output_panel(PANEL_NAME)
+        if panel_view:
+            panel_view.set_read_only(False)
+            panel_view.run_command(
+                'append',
+                {'characters': msg, 'force': True, 'scroll_to_end': True})
+            panel_view.set_read_only(True)
+        else:
+            print("panel not found")

--- a/common/util/log.py
+++ b/common/util/log.py
@@ -4,3 +4,8 @@ import sublime
 def panel(*msgs):
     msg = "\n".join(str(msg) for msg in msgs)
     sublime.active_window().active_view().run_command("gs_display_panel", {"msg": msg})
+
+
+def panel_append(*msgs):
+    msg = "\n".join(str(msg) for msg in msgs)
+    sublime.active_window().active_view().run_command("gs_append_panel", {"msg": msg})

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -192,11 +192,18 @@ class GitCommand(StatusMixin,
 
             if show_panel and live_panel_output:
                 if savvy_settings.get("show_input_in_output"):
-                    util.log.panel(command_str + "\n\n")
+                    util.log.panel("> {}\n\n".format(command_str))
                 wrapper = LoggingProcessWrapper(p)
                 stdout, stderr = wrapper.communicate(stdin)
             else:
                 stdout, stderr = p.communicate(stdin)
+                if show_panel:
+                    util.log.panel("")
+                    if savvy_settings.get("show_stdin_in_output") and stdin is not None:
+                        util.log.panel_append("STDIN\n{}\n".format(original_stdin))
+                    if savvy_settings.get("show_input_in_output"):
+                        util.log.panel_append("> {}\n".format(command_str))
+                    util.log.panel_append("{}\n{}".format(stdout, stderr))
 
             if decode:
                 stdout, stderr = self.decode_stdout(stdout, savvy_settings), stderr.decode()
@@ -233,12 +240,6 @@ class GitCommand(StatusMixin,
                 ))
             else:
                 raise GitSavvyError("`{}` failed.".format(command_str))
-
-        if show_panel:
-            if savvy_settings.get("show_input_in_output"):
-                util.log.panel("> {}\n{}\n{}".format(command_str, stdout, stderr))
-            else:
-                util.log.panel("{}\n{}".format(stdout, stderr))
 
         return stdout
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -98,6 +98,8 @@ class LoggingProcessWrapper(object):
         stderr_thread.start()
 
         self.process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
 
         return self.stdout, self.stderr
 
@@ -153,7 +155,7 @@ class GitCommand(StatusMixin,
         if args[0] in close_panel_for:
             sublime.active_window().run_command("hide_panel", {"cancel": True})
 
-        live_panel_output = savvy_settings.get("live_panel_output") or False
+        live_panel_output = savvy_settings.get("live_panel_output", False)
 
         stdout, stderr = None, None
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -98,8 +98,14 @@ class LoggingProcessWrapper(object):
         stderr_thread.start()
 
         self.process.wait()
-        stdout_thread.join()
-        stderr_thread.join()
+
+        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        timeout = savvy_settings.get("live_panel_output_timeout", 10000)
+        # 10s timeout default
+        max_run_time = time.monotonic() - timeout
+
+        stdout_thread.join(self.process._remaining_time(max_run_time))
+        stderr_thread.join(self.process._remaining_time(max_run_time))
 
         return self.stdout, self.stderr
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -187,12 +187,16 @@ class GitCommand(StatusMixin,
                                  env=environ,
                                  startupinfo=startupinfo)
 
+            original_stdin = stdin
             if stdin is not None and encode:
                 stdin = stdin.encode(encoding=stdin_encoding)
 
             if show_panel and live_panel_output:
+                util.log.panel("")
+                if savvy_settings.get("show_stdin_in_output") and stdin is not None:
+                    util.log.panel_append("STDIN\n{}\n".format(original_stdin))
                 if savvy_settings.get("show_input_in_output"):
-                    util.log.panel("> {}\n\n".format(command_str))
+                    util.log.panel_append("> {}\n\n".format(command_str))
                 wrapper = LoggingProcessWrapper(p)
                 stdout, stderr = wrapper.communicate(stdin)
             else:


### PR DESCRIPTION
This is an exploration for new feature to show stdout/stderr output in a Sublime Text panel while a hook is running, as discussed in #812

Currently pre-push (logs to stdout) and pre-commit (logs to stderr) hooks have been tested on OS-X.

Some demos (bad gif conversion results in 2x slower playback, sorry for your time :) )

**Commit** (Commit view closes automatically)

![gitsavvy-commit-hook](https://user-images.githubusercontent.com/4395832/32896946-a82be71a-cae4-11e7-9326-fc07c5f411c7.gif)

**Push** 

![gitsavvy-push-hook](https://user-images.githubusercontent.com/4395832/32897020-cce8f638-cae4-11e7-9a83-16402b0b1075.gif)



