### PR TITLE
Fix: find() returns index instead of True/False

### DIFF
--- a/core/commands/changelog.py
+++ b/core/commands/changelog.py
@@ -59,7 +59,7 @@ class GsGenerateChangeLogCommand(WindowCommand, GitCommand):
             contributors.add(entry.author)
             if entry.long_hash in ancestor:
                 messages.append("{} (Merge {})".format(entry.summary, ancestor[entry.long_hash]))
-            elif entry.raw_body.find('BREAKING:'):
+            elif entry.raw_body.find('BREAKING:') >= 0:
                 pos_start = entry.raw_body.find('BREAKING:')
                 key_length = len('BREAKING:')
                 indented_sub_msg = ('\n\t\t' + ' ' * key_length + ' ').join(entry.raw_body[pos_start:].split('\n'))


### PR DESCRIPTION
When the pattern is not found, `find()` returns -1 instead.