### PR TITLE
git remote rename and show remote url

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -110,6 +110,10 @@
         "command": "gs_remote_remove"
     },
     {
+        "caption": "git: remote rename",
+        "command": "gs_remote_rename"
+    },
+    {
         "caption": "git: checkout",
         "command": "gs_checkout_branch"
     },

--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -1,38 +1,38 @@
 import sublime
-from sublime_plugin import TextCommand
+from sublime_plugin import WindowCommand
 
 from ..git_command import GitCommand
 from ...common import util
 from ..ui_mixins.quick_panel import show_remote_panel
 
 
-class GsRemoteAddCommand(TextCommand, GitCommand):
+class GsRemoteAddCommand(WindowCommand, GitCommand):
     """
     Add remotes
     """
 
-    def run(self, edit):
+    def run(self):
         # Get remote name from user
-        self.view.window().show_input_panel("Remote URL", "", self.on_enter_remote, None, None)
+        self.window.show_input_panel("Remote URL", "", self.on_enter_remote, None, None)
 
     def on_enter_remote(self, input_url):
         self.url = input_url
         owner = self.username_from_url(input_url)
 
-        self.view.window().show_input_panel("Remote name", owner, self.on_enter_name, None, None)
+        self.window.show_input_panel("Remote name", owner, self.on_enter_name, None, None)
 
     def on_enter_name(self, remote_name):
         self.git("remote", "add", remote_name, self.url)
         if sublime.ok_cancel_dialog("Your remote was added successfully.  Would you like to fetch from this remote?"):
-            self.view.window().run_command("gs_fetch", {"remote": remote_name})
+            self.window.run_command("gs_fetch", {"remote": remote_name})
 
 
-class GsRemoteRemoveCommand(TextCommand, GitCommand):
+class GsRemoteRemoveCommand(WindowCommand, GitCommand):
     """
     Remove remotes
     """
 
-    def run(self, edit):
+    def run(self):
         show_remote_panel(self.on_remote_selection, show_url=True)
 
     def on_remote_selection(self, remote):
@@ -44,3 +44,24 @@ class GsRemoteRemoveCommand(TextCommand, GitCommand):
             self.git("remote", "remove", remote)
 
         remove()
+
+
+class GsRemoteRenameCommand(WindowCommand, GitCommand):
+    """
+    Reame remotes
+    """
+
+    def run(self):
+        show_remote_panel(self.on_remote_selection, show_url=True)
+
+    def on_remote_selection(self, remote):
+        if not remote:
+            return
+
+        self.remote = remote
+        v = self.window.show_input_panel("Remote name", remote, self.on_enter_name, None, None)
+        v.run_command("select_all")
+
+    def on_enter_name(self, new_name):
+        self.git("remote", "rename", self.remote, new_name)
+        sublime.status_message("remote {} was renamed as {}.".format(self.remote, new_name))

--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -33,7 +33,7 @@ class GsRemoteRemoveCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
-        show_remote_panel(self.on_remote_selection)
+        show_remote_panel(self.on_remote_selection, show_url=True)
 
     def on_remote_selection(self, remote):
         if not remote:

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -113,7 +113,9 @@ class PanelCommandMixin(PanelActionMixin):
         return ((selected_action[0], ) + args), kwargs
 
 
-def show_remote_panel(on_done, show_option_all=False, selected_remote=None, allow_direct=False):
+def show_remote_panel(
+    on_done, show_option_all=False, selected_remote=None, allow_direct=False,
+    show_url=False):
     """
     Show a quick panel with remotes. The callback `on_done(remote)` will
     be called when a remote is selected. If the panel is cancelled, `None`
@@ -123,22 +125,25 @@ def show_remote_panel(on_done, show_option_all=False, selected_remote=None, allo
     show_option_all: whether the option "All remotes" should be shown. `True` will
                 be passed to `on_done` if the all remotes option is selected.
     """
-    rp = RemotePanel(on_done, show_option_all, selected_remote, allow_direct)
+    rp = RemotePanel(on_done, show_option_all, selected_remote, allow_direct, show_url)
     rp.show()
     return rp
 
 
 class RemotePanel(GitCommand):
 
-    def __init__(self, on_done, show_option_all=False, selected_remote=None, allow_direct=False):
+    def __init__(self, on_done, show_option_all=False, selected_remote=None,
+            allow_direct=False, show_url=False):
         self.window = sublime.active_window()
         self.on_done = on_done
         self.selected_remote = selected_remote
         self.show_option_all = show_option_all
         self.allow_direct = allow_direct
+        self.show_url = show_url
 
     def show(self):
-        self.remotes = list(self.get_remotes().keys())
+        _remotes = self.get_remotes()
+        self.remotes = list(_remotes.keys())
 
         if not self.remotes:
             self.window.show_quick_panel(["There are no remotes available."], None)
@@ -160,7 +165,7 @@ class RemotePanel(GitCommand):
             pre_selected_index = 0
 
         self.window.show_quick_panel(
-            self.remotes,
+            [[remote, _remotes[remote]] for remote in self.remotes] if self.show_url else self.remotes,
             self.on_remote_selection,
             flags=sublime.MONOSPACE_FONT,
             selected_index=pre_selected_index


### PR DESCRIPTION
- new command `git: remote rename`

- Enhancement: show url when using `git: remote`

![screen shot 2017-12-07 at 2 39 56 pm](https://user-images.githubusercontent.com/1690993/33735172-88f259c8-db5c-11e7-95b6-8b0529fcf9f3.png)