### PR TITLE
Fix: only show diff patch when `show_commit_diff` is "full"

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -110,15 +110,18 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
             with util.file.safe_open(commit_help_extra_path, "r", encoding="utf-8") as f:
                 initial_text += f.read()
 
-        show_commit_diff = savvy_settings.get("show_commit_diff")
         git_args = [
             "diff",
-            "--patch",
             "--no-color"
         ]
 
+        show_commit_diff = savvy_settings.get("show_commit_diff")
+        # for backward compatibility, check also if show_commit_diff is True
+        if show_commit_diff is True or show_commit_diff == "full":
+            git_args.append("--patch")
+
         show_diffstat = savvy_settings.get("show_diffstat")
-        if show_diffstat:
+        if show_commit_diff == "stat" or (show_commit_diff == "full" and show_diffstat):
             git_args.append("--stat")
 
         if not include_unstaged:


### PR DESCRIPTION
My last PR #827 was not correctly done.