### PR TITLE
Feature/pull remote tracking

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -141,8 +141,12 @@
         "command": "gs_pull"
     },
     {
-        "caption": "git: pull with rebase",
-        "command": "gs_pull",
+        "caption": "git: pull from branch",
+        "command": "gs_pull_from_branch"
+    },
+    {
+        "caption": "git: pull from branch with rebase",
+        "command": "gs_pull_from_branch",
         "args": { "rebase": true }
     },
     {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -141,6 +141,11 @@
         "command": "gs_pull"
     },
     {
+        "caption": "git: pull with rebase",
+        "command": "gs_pull",
+        "args": { "rebase": true }
+    },
+    {
         "caption": "git: pull from branch",
         "command": "gs_pull_from_branch"
     },

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -12,16 +12,14 @@ class GsPullCommand(WindowCommand, GitCommand):
     Through a series of panels, allow the user to pull from a remote branch.
     """
 
-    def run(self, local_branch_name=None, rebase=False):
-        self.local_branch_name = local_branch_name
+    def run(self, rebase=False):
         self.rebase = rebase
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
         show_branch_panel(
             self.on_branch_selection,
-            ask_remote_first=True,
-            selected_branch=self.local_branch_name)
+            ask_remote_first=True)
 
     def on_branch_selection(self, branch):
         if not branch:

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -23,14 +23,17 @@ class GsPull(WindowCommand, GsPullBase):
     Pull from remote tracking branch if it is found. Otherwise, use GsPullFromBranchCommand.
     """
 
-    def run(self):
+    def run(self, rebase=False):
+        self.rebase = rebase
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
-        # honor the `pull.rebase` config implictly
-        rebase = self.git("config", "pull.rebase", throw_on_stderr=False) or False
-        if rebase and rebase.strip() == "true":
-            rebase = True
+        rebase = self.rebase
+        if not rebase:
+            # honor the `pull.rebase` config implictly
+            pull_rebase = self.git("config", "pull.rebase", throw_on_stderr=False)
+            if pull_rebase and pull_rebase.strip() == "true":
+                rebase = True
         upstream = self.get_upstream_for_active_branch()
         if upstream:
             remote, remote_branch = upstream.split("/", 1)

--- a/docs/remotes.md
+++ b/docs/remotes.md
@@ -15,6 +15,10 @@ Assuming you've recently fetched, this command allows you to create a local bran
 This command will pull current branch from the tracking branch. If the tracking branch is not set, you will be prompted. If the git config `pull.rebase` is set true, the command will be execulated with `--rebase`.
 
 
+## `git: pull with rebase`
+
+Like `git: pull`, but rebasing on the remote branch explictly.
+
 ## `git: pull from branch`
 
 When running this command, you will be prompted first for the remote you want to pull from, and then the branch.  If your local branch tracks a remote, that branch name will be pre-selected at the second prompt.

--- a/docs/remotes.md
+++ b/docs/remotes.md
@@ -12,11 +12,16 @@ Assuming you've recently fetched, this command allows you to create a local bran
 
 ## `git: pull`
 
+This command will pull current branch from the tracking branch. If the tracking branch is not set, you will be prompted. If the git config `pull.rebase` is set true, the command will be execulated with `--rebase`.
+
+
+## `git: pull from branch`
+
 When running this command, you will be prompted first for the remote you want to pull from, and then the branch.  If your local branch tracks a remote, that branch name will be pre-selected at the second prompt.
 
-## `git: pull with rebase`
+## `git: pull from branch with rebase`
 
-Like `git: pull`, but rebasing on the remote branch instead of merging.
+Like `git: pull from branch`, but rebasing on the remote branch instead of merging.
 
 **For the following commands you need to configure a username and password in git, so GitSavvy can use it.**
 


### PR DESCRIPTION
The current implementation of `git: pull` requires users to choose a remote and then a branch to pull. However, 99% of times and 90% of users will just hit "enter" and "enter" to pull from the default remote tracking branch. 

This PR changes the behaviour of `git: pull` to pull from remote tracking branch directly if it is found. And the original command `git: pull` is now renamed as `git: pull from branch` to mirror `git: push from existing branch` (the word 'existing' seems redundant here).