### PR TITLE
Internal: Use window.status_message instead of sublime.status_message

### DIFF
--- a/common/ui.py
+++ b/common/ui.py
@@ -183,7 +183,7 @@ class Interface():
     def get_selection_line(self):
         selections = self.view.sel()
         if not selections or len(selections) > 1:
-            sublime.status_message("Please make a selection.")
+            self.view.window().status_message("Please make a selection.")
             return None
 
         selection = selections[0]

--- a/core/commands/amend.py
+++ b/core/commands/amend.py
@@ -14,5 +14,5 @@ class GsAmendCommand(WindowCommand, GitCommand):
 class GsQuickStageCurrentFileAndAmendCommand(GsAmendCommand, GitCommand):
     def run(self):
         self.git("add", "--", self.file_path)
-        sublime.status_message("staged {}".format(self.get_rel_path(self.file_path)))
+        self.window.status_message("staged {}".format(self.get_rel_path(self.file_path)))
         super().run()

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -451,7 +451,7 @@ class GsBlameToggleSetting(BlameMixin, TextCommand):
         else:
             settings.set(setting_str, not settings.get(setting_str))
 
-        sublime.status_message("{} is now {}".format(setting, settings.get(setting_str)))
+        self.view.window().status_message("{} is now {}".format(setting, settings.get(setting_str)))
         self.view.settings().set("git_savvy.lineno", self.find_lineno())
         self.view.run_command("gs_blame_refresh")
 

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -36,7 +36,7 @@ class GsCheckoutBranchCommand(WindowCommand, GitCommand):
             return
 
         self.git("checkout", branch)
-        sublime.status_message("Checked out `{}` branch.".format(branch))
+        self.window.status_message("Checked out `{}` branch.".format(branch))
         util.view.refresh_gitsavvy(self.window.active_view(), refresh_sidebar=True)
 
 
@@ -66,7 +66,7 @@ class GsCheckoutNewBranchCommand(WindowCommand, GitCommand):
             "checkout", "-b",
             branch_name,
             self.base_branch if self.base_branch else None)
-        sublime.status_message("Created and checked out `{}` branch.".format(branch_name))
+        self.window.status_message("Created and checked out `{}` branch.".format(branch_name))
         util.view.refresh_gitsavvy(
             self.window.active_view(),
             refresh_sidebar=True,
@@ -116,7 +116,7 @@ class GsCheckoutRemoteBranchCommand(WindowCommand, GitCommand):
             return None
 
         self.git("checkout", "-b", branch_name, "--track", self.remote_branch)
-        sublime.status_message(
+        self.window.status_message(
             "Checked out `{}` as local branch `{}`.".format(self.remote_branch, branch_name))
         util.view.refresh_gitsavvy(
             self.window.active_view(),
@@ -134,4 +134,4 @@ class GsCheckoutCurrentFileCommand(WindowCommand, GitCommand):
     def run(self):
         if self.file_path:
             self.checkout_file(self.file_path)
-            sublime.status_message("Successfully checked out {} from head.".format(self.file_path))
+            self.window.status_message("Successfully checked out {} from head.".format(self.file_path))

--- a/core/commands/cherry_pick.py
+++ b/core/commands/cherry_pick.py
@@ -14,6 +14,6 @@ class GsCherryPickCommand(GsLogByBranchCommand):
 
     def do_action(self, commit_hash, **kwargs):
         self.git("cherry-pick", commit_hash)
-        sublime.status_message("Commit %s cherry-picked successfully." %
+        self.view.window().status_message("Commit %s cherry-picked successfully." %
                                commit_hash)
         util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/custom.py
+++ b/core/commands/custom.py
@@ -64,14 +64,14 @@ class GsCustomCommand(WindowCommand, GitCommand):
             elif arg == "{PROMPT_ARG}":
                 args[idx] = custom_argument
 
-        sublime.status_message(start_msg)
+        self.window.status_message(start_msg)
         if run_in_thread:
             stdout = ''
             cmd_thread = CustomCommandThread(self.git, *args, custom_environ=custom_environ)
             cmd_thread.start()
         else:
             stdout = self.git(*args, custom_environ=custom_environ)
-        sublime.status_message(complete_msg)
+        self.window.status_message(complete_msg)
 
         if output_to_panel:
             util.log.panel(stdout.replace("\r", "\n"))

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -132,7 +132,7 @@ class GsDiffToggleSetting(TextCommand):
         setting_str = "git_savvy.diff_view.{}".format(setting)
         settings = self.view.settings()
         settings.set(setting_str, not settings.get(setting_str))
-        sublime.status_message("{} is now {}".format(setting, settings.get(setting_str)))
+        self.view.window().status_message("{} is now {}".format(setting, settings.get(setting_str)))
         self.view.run_command("gs_diff_refresh")
 
 

--- a/core/commands/fetch.py
+++ b/core/commands/fetch.py
@@ -29,10 +29,10 @@ class GsFetchCommand(WindowCommand, GitCommand):
 
     def do_fetch(self, remote=None):
         if remote is None:
-            sublime.status_message("Starting fetch all remotes...")
+            self.window.status_message("Starting fetch all remotes...")
         else:
-            sublime.status_message("Starting fetch {}...".format(remote))
+            self.window.status_message("Starting fetch {}...".format(remote))
 
         self.fetch(remote)
-        sublime.status_message("Fetch complete.")
+        self.window.status_message("Fetch complete.")
         util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/flow.py
+++ b/core/commands/flow.py
@@ -166,7 +166,7 @@ class GsGitFlowInitCommand(FlowCommon):
 
     def on_versiontag_selected(self, tag):
         self.configure_gitflow('prefix.versiontag', tag)
-        sublime.status_message("git flow initialized")
+        self.window.status_message("git flow initialized")
 
 
 class CompleteMixin(object):
@@ -179,7 +179,7 @@ class CompleteMixin(object):
         self.show_status_update()
 
     def show_status_update(self):
-        sublime.status_message("%s %sed, checked out %s" %
+        self.window.status_message("%s %sed, checked out %s" %
                                (self.flow.capitalize(), self.command,
                                 self.get_current_branch_name()))
 
@@ -243,7 +243,7 @@ class GenericPublishMixin(CompleteMixin, GenericSelectTargetBranch):
     command = 'publish'
 
     def show_status_update(self):
-        sublime.status_message("%s %sed" % (self.flow.capitalize(),
+        self.window.status_message("%s %sed" % (self.flow.capitalize(),
                                             self.command))
 
 

--- a/core/commands/ignore.py
+++ b/core/commands/ignore.py
@@ -23,7 +23,7 @@ class GsIgnoreCommand(WindowCommand, GitCommand):
             file_path_or_pattern = self.file_path
 
         self.add_ignore(os.path.join("/", file_path_or_pattern))
-        sublime.status_message("Ignored file `{}`.".format(file_path_or_pattern))
+        self.window.status_message("Ignored file `{}`.".format(file_path_or_pattern))
         util.view.refresh_gitsavvy(self.window.active_view())
 
 
@@ -39,7 +39,7 @@ class GsIgnorePatternCommand(WindowCommand, GitCommand):
 
     def on_done(self, ignore_pattern):
         self.add_ignore(ignore_pattern)
-        sublime.status_message("Ignored pattern `{}`.".format(ignore_pattern))
+        self.window.status_message("Ignored pattern `{}`.".format(ignore_pattern))
         util.view.refresh_gitsavvy(self.window.active_view())
 
 

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -72,7 +72,7 @@ class GsInit(WindowCommand, GitCommand):
 
     def on_done(self, path, re_init=False):
         self.git("init", working_dir=path)
-        sublime.status_message("{word_start}nitialized repo successfully.".format(
+        self.window.status_message("{word_start}nitialized repo successfully.".format(
             word_start="Re-i" if re_init else "I"))
         util.view.refresh_gitsavvy(self.window.active_view())
 
@@ -117,9 +117,9 @@ class GsClone(WindowCommand, GitCommand):
         sublime.set_timeout_async(self.do_clone, 0)
 
     def do_clone(self):
-        sublime.status_message("Start cloning {}".format(self.git_url))
+        self.window.status_message("Start cloning {}".format(self.git_url))
         self.git("clone", self.git_url, self.suggested_git_root, working_dir='.')
-        sublime.status_message("Cloned repo successfully.")
+        self.window.status_message("Cloned repo successfully.")
         self.open_folder()
         util.view.refresh_gitsavvy(self.window.active_view())
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -200,7 +200,7 @@ class GsLogGraphActionCommand(GsLogActionCommand):
         self._file_path = self.file_path
 
         if not len(self.selections) == 1:
-            sublime.status_message("You can only do actions on one commit at a time.")
+            self.window.status_message("You can only do actions on one commit at a time.")
             return
 
         super().run(commit_hash=self._commit_hash, file_path=self._file_path)

--- a/core/commands/pull.py
+++ b/core/commands/pull.py
@@ -12,9 +12,9 @@ class GsPullBase(GitCommand):
         """
         Perform `git pull remote branch`.
         """
-        sublime.status_message("Starting pull...")
+        self.view.window().status_message("Starting pull...")
         self.pull(remote=remote, remote_branch=remote_branch, rebase=rebase)
-        sublime.status_message("Pull complete.")
+        self.view.window().status_message("Pull complete.")
         util.view.refresh_gitsavvy(self.window.active_view())
 
 

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -27,7 +27,7 @@ class PushBase(GitCommand):
             if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH):
                 return
 
-        sublime.status_message(START_PUSH_MESSAGE)
+        self.window.status_message(START_PUSH_MESSAGE)
         self.push(
             remote,
             branch,
@@ -35,7 +35,7 @@ class PushBase(GitCommand):
             force=force,
             remote_branch=remote_branch
             )
-        sublime.status_message(END_PUSH_MESSAGE)
+        self.window.status_message(END_PUSH_MESSAGE)
         util.view.refresh_gitsavvy(self.window.active_view())
 
 

--- a/core/commands/quick_commit.py
+++ b/core/commands/quick_commit.py
@@ -26,7 +26,7 @@ class GsQuickCommitCommand(WindowCommand, GitCommand):
 
     def on_done(self, commit_message):
         self.git("commit", "-q", "-F", "-", stdin=commit_message)
-        sublime.status_message("Committed successfully.")
+        self.window.status_message("Committed successfully.")
         util.view.refresh_gitsavvy(self.window.active_view())
 
 
@@ -50,5 +50,5 @@ class GsQuickStageCurrentFileCommitCommand(WindowCommand, GitCommand):
     def on_done(self, commit_message):
         self.git("add", "--", self.file_path)
         self.git("commit", "-q", "-F", "-", stdin=commit_message)
-        sublime.status_message("Committed successfully.")
+        self.window.status_message("Committed successfully.")
         util.view.refresh_gitsavvy(self.window.active_view())

--- a/core/commands/quick_stage.py
+++ b/core/commands/quick_stage.py
@@ -80,7 +80,7 @@ class GsQuickStageCommand(WindowCommand, GitCommand):
                 self.git("add", "--update", "--", selection.filename)
                 scope_of_action = "`{}`".format(selection.filename)
 
-            sublime.status_message("Successfully added `{}`.".format(
+            self.window.status_message("Successfully added `{}`.".format(
                 scope_of_action))
             util.view.refresh_gitsavvy(self.window.active_view())
 

--- a/core/commands/remote.py
+++ b/core/commands/remote.py
@@ -67,4 +67,4 @@ class GsRemoteRenameCommand(WindowCommand, GitCommand):
 
     def on_enter_name(self, new_name):
         self.git("remote", "rename", self.remote, new_name)
-        sublime.status_message("remote {} was renamed as {}.".format(self.remote, new_name))
+        self.window.status_message("remote {} was renamed as {}.".format(self.remote, new_name))

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -63,7 +63,7 @@ class GsShowCommitToggleSetting(TextCommand):
         setting_str = "git_savvy.show_commit_view.{}".format(setting)
         settings = self.view.settings()
         settings.set(setting_str, not settings.get(setting_str))
-        sublime.status_message("{} is now {}".format(setting, settings.get(setting_str)))
+        self.view.window().status_message("{} is now {}".format(setting, settings.get(setting_str)))
         self.view.run_command("gs_show_commit_refresh")
 
 

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -124,7 +124,7 @@ class GsTagCreateCommand(TextCommand, GitCommand):
             return
 
         self.git("tag", self.tag_name, "-F", "-", stdin=message)
-        sublime.status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
+        self.view.window().status_message(TAG_CREATE_MESSAGE.format(self.tag_name))
         util.view.refresh_gitsavvy(self.view)
 
 

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -9,7 +9,7 @@ class GitSavvyError(Exception):
             if kwargs.get('show_panel', True):
                 util.log.panel(msg)
             if kwargs.get('show_status', False):
-                sublime.status_message(msg)
+                sublime.active_window().status_message(msg)
             util.debug.log_error(msg)
 
 

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -150,7 +150,7 @@ class GitCommand(StatusMixin,
                 )
 
         if throw_on_stderr and not p.returncode == 0:
-            sublime.status_message(
+            sublime.active_window().status_message(
                 "Failed to run `git {}`. See log for details.".format(command[1])
             )
 

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -293,19 +293,19 @@ class GsBranchesDeleteCommand(TextCommand, GitCommand):
             "-D" if self.force else "-d",
             branch_name
             )
-        sublime.status_message("Deleted local branch.")
+        self.view.window().status_message("Deleted local branch.")
         util.view.refresh_gitsavvy(self.view)
 
     @util.actions.destructive(description="delete a remote branch")
     def delete_remote_branch(self, remote, branch_name):
-        sublime.status_message("Deleting remote branch...")
+        self.view.window().status_message("Deleting remote branch...")
         self.git(
             "push",
             "--force" if self.force else None,
             remote,
             ":"+branch_name
             )
-        sublime.status_message("Deleted remote branch.")
+        self.view.window().status_message("Deleted remote branch.")
         util.view.refresh_gitsavvy(self.view)
 
 
@@ -404,9 +404,9 @@ class GsBranchesPushAllCommand(TextCommand, GitCommand):
         # If the user pressed `esc` or otherwise cancelled.
         if not remote:
             return
-        sublime.status_message("Pushing all branches to `{}`...".format(remote))
+        self.view.window().status_message("Pushing all branches to `{}`...".format(remote))
         self.git("push", remote, "--all")
-        sublime.status_message("Push successful.")
+        self.view.window().status_message("Push successful.")
         util.view.refresh_gitsavvy(self.view)
 
 
@@ -455,7 +455,7 @@ class GsBranchesFetchAndMergeCommand(TextCommand, GitCommand):
 
         branches_strings = self.interface.create_branches_strs(branches)
         self.merge(branches_strings)
-        sublime.status_message("Fetch and merge complete.")
+        self.view.window().status_message("Fetch and merge complete.")
         util.view.refresh_gitsavvy(self.view)
 
 

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -357,7 +357,7 @@ class GsStatusStageFileCommand(TextCommand, GitCommand):
         if file_paths:
             for fpath in file_paths:
                 self.stage_file(fpath, force=False)
-            sublime.status_message("Staged files successfully.")
+            self.view.window().status_message("Staged files successfully.")
             util.view.refresh_gitsavvy(self.view)
 
 
@@ -382,7 +382,7 @@ class GsStatusUnstageFileCommand(TextCommand, GitCommand):
         if file_paths:
             for fpath in file_paths:
                 self.unstage_file(fpath)
-            sublime.status_message("Unstaged files successfully.")
+            self.view.window().status_message("Unstaged files successfully.")
             util.view.refresh_gitsavvy(self.view)
 
 
@@ -398,7 +398,7 @@ class GsStatusDiscardChangesToFileCommand(TextCommand, GitCommand):
         self.discard_untracked(interface)
         self.discard_unstaged(interface)
         util.view.refresh_gitsavvy(self.view)
-        sublime.status_message("Successfully discarded changes.")
+        self.view.window().status_message("Successfully discarded changes.")
 
     def discard_untracked(self, interface):
         valid_ranges = interface.get_view_regions("untracked_files")
@@ -564,7 +564,7 @@ class GsStatusIgnoreFileCommand(TextCommand, GitCommand):
         if file_paths:
             for fpath in file_paths:
                 self.add_ignore(os.path.join("/", fpath))
-            sublime.status_message("Successfully ignored files.")
+            self.view.window().status_message("Successfully ignored files.")
             util.view.refresh_gitsavvy(self.view)
 
 
@@ -625,7 +625,7 @@ class GsStatusStashCommand(TextCommand, GitCommand):
             return
 
         if len(ids) > 1:
-            sublime.status_message("You can only {} one stash at a time.".format(action))
+            self.view.window().status_message("You can only {} one stash at a time.".format(action))
             return
 
         if action == "apply":

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -235,7 +235,7 @@ class GsTagsDeleteCommand(TextCommand, GitCommand):
         for tag in tags_to_delete:
             self.git("tag", "-d", tag)
 
-        sublime.status_message(TAG_DELETE_MESSAGE)
+        self.view.window().status_message(TAG_DELETE_MESSAGE)
         util.view.refresh_gitsavvy(self.view)
 
     def delete_remote(self, interface):
@@ -254,7 +254,7 @@ class GsTagsDeleteCommand(TextCommand, GitCommand):
                     *("refs/tags/" + tag for tag in tags_to_delete)
                     )
 
-        sublime.status_message(TAG_DELETE_MESSAGE)
+        self.view.window().status_message(TAG_DELETE_MESSAGE)
         interface.remotes = None
         util.view.refresh_gitsavvy(self.view)
 
@@ -297,9 +297,9 @@ class GsTagsPushCommand(TextCommand, GitCommand):
         lines = interface.get_selection_lines_in_region("local_tags")
         tags_to_push = tuple(line[12:].strip() for line in lines if line)
 
-        sublime.status_message(START_PUSH_MESSAGE)
+        self.view.window().status_message(START_PUSH_MESSAGE)
         self.git("push", remote, *("refs/tags/" + tag for tag in tags_to_push))
-        sublime.status_message(END_PUSH_MESSAGE)
+        self.view.window().status_message(END_PUSH_MESSAGE)
 
         interface.remotes = None
         util.view.refresh_gitsavvy(self.view)
@@ -309,9 +309,9 @@ class GsTagsPushCommand(TextCommand, GitCommand):
         if remote_idx == -1:
             return
         remote = self.remotes[remote_idx]
-        sublime.status_message(START_PUSH_MESSAGE)
+        self.view.window().status_message(START_PUSH_MESSAGE)
         self.git("push", remote, "--tags")
-        sublime.status_message(END_PUSH_MESSAGE)
+        self.view.window().status_message(END_PUSH_MESSAGE)
 
         interface = ui.get_interface(self.view.id())
         if interface:

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -386,12 +386,12 @@ class PaginatedPanel:
 
     def show(self):
         if self.status_message:
-            sublime.status_message(self.status_message)
+            sublime.active_window().status_message(self.status_message)
         try:
             self.load_next_batch()
         finally:
             if self.status_message:
-                sublime.status_message("")
+                sublime.active_window().status_message("")
 
         if len(self.display_list) == self.limit:
             self.display_list.append(self.next_page_message)

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -61,7 +61,7 @@ class GsShowGithubIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemote
             status_message="Getting issues..."
             )
         if pp.is_empty():
-            sublime.status_message("No issues found.")
+            self.view.window().status_message("No issues found.")
 
     def format_item(self, issue):
         return (
@@ -111,7 +111,7 @@ class GsShowGithubContributorsCommand(TextCommand, GitCommand):
             status_message="Getting contributors..."
             )
         if pp.is_empty():
-            sublime.status_message("No contributors found.")
+            self.view.window().status_message("No contributors found.")
 
     def format_item(self, contributor):
         return (contributor["login"], contributor)

--- a/github/commands/configure.py
+++ b/github/commands/configure.py
@@ -32,4 +32,4 @@ class GsConfigureGithubRemoteCommand(WindowCommand, GithubRemotesMixin, GitComma
         self.git("config", "--local", "--unset-all", "GitSavvy.ghBranch", throw_on_stderr=False)
         self.git("config", "--local", "--add", "GitSavvy.ghBranch", remote_branch)
 
-        sublime.status_message("Successfully configured GitHub integration.")
+        self.window.status_message("Successfully configured GitHub integration.")

--- a/github/commands/create_fork.py
+++ b/github/commands/create_fork.py
@@ -24,9 +24,9 @@ class GsCreateForkCommand(PanelCommandMixin, WindowCommand, GitCommand,
 
     def run_async(self):
         base_remote = github.parse_remote(self.get_integrated_remote_url())
-        sublime.status_message(START_CREATE_MESSAGE.format(repo=base_remote))
+        self.window.status_message(START_CREATE_MESSAGE.format(repo=base_remote))
         result = github.create_fork(base_remote)
-        sublime.status_message(END_CREATE_MESSAGE)
+        self.window.status_message(END_CREATE_MESSAGE)
         util.debug.add_to_log(("github: fork result:\n{}".format(result)))
         self.window.show_quick_panel(
             ["Fork created, do you want to add it as remote?",

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -39,7 +39,7 @@ class GsPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMi
             status_message="Getting pull requests..."
             )
         if pp.is_empty():
-            sublime.status_message("No pull requests found.")
+            self.window.status_message("No pull requests found.")
 
     def format_item(self, issue):
         return (
@@ -96,7 +96,7 @@ class GsPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMi
             self.open_pr_in_browser()
 
     def fetch_and_checkout_pr(self, branch_name=None):
-        sublime.status_message("Fetching PR commit...")
+        self.window.status_message("Fetching PR commit...")
         self.git(
             "fetch",
             self.pr["head"]["repo"]["clone_url"],
@@ -104,25 +104,25 @@ class GsPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRemotesMi
             )
 
         if branch_name:
-            sublime.status_message("Creating local branch for PR...")
+            self.window.status_message("Creating local branch for PR...")
             self.git(
                 "branch",
                 branch_name,
                 self.pr["head"]["sha"]
                 )
 
-        sublime.status_message("Checking out PR...")
+        self.window.status_message("Checking out PR...")
         self.checkout_ref(branch_name or self.pr["head"]["sha"])
 
     def create_branch_for_pr(self, branch_name):
-        sublime.status_message("Fetching PR commit...")
+        self.window.status_message("Fetching PR commit...")
         self.git(
             "fetch",
             self.pr["head"]["repo"]["clone_url"],
             self.pr["head"]["ref"]
             )
 
-        sublime.status_message("Creating local branch for PR...")
+        self.window.status_message("Creating local branch for PR...")
         self.git(
             "branch",
             branch_name,


### PR DESCRIPTION
`sublime.status_message` is no longer officially there in the api doc so it is better to use in on a window. 

And  if we don't know which window we can use `sublime.active_window().status_message`