### PR TITLE
Tools to handle merge conflicts

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -288,6 +288,10 @@
         "command": "gs_abort_merge"
     },
     {
+        "caption": "git: abort rebase",
+        "command": "gs_rebase_abort"
+    },
+    {
         "caption": "git: restart merge for file...",
         "command": "gs_restart_merge_for_file"
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -180,6 +180,32 @@
             { "key": "selector", "operator": "equal", "operand": "git-savvy.status meta.git-savvy.status.section meta.git-savvy.status.file" }
         ]
     },
+    {
+        "keys": ["y"],
+        "command": "gs_status_use_commit_version",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.status meta.git-savvy.status.section.merge-conflicts meta.git-savvy.status.file" }
+        ]
+    },
+    {
+        "keys": ["b"],
+        "command": "gs_status_use_base_version",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.status meta.git-savvy.status.section.merge-conflicts meta.git-savvy.status.file" }
+        ]
+    },
+    {
+        "keys": ["B"],
+        "command": "gs_abort_merge",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.status_view", "operator": "equal", "operand": true }
+        ]
+    },
 
 
     /////////////////////////////

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -1,3 +1,4 @@
+import os
 from collections import namedtuple
 from ..constants import MERGE_CONFLICT_PORCELAIN_STATUSES
 
@@ -111,3 +112,12 @@ class StatusMixin():
                 staged.append(f)
 
         return staged, unstaged, untracked, conflicts
+
+    def in_merge(self):
+        return os.path.exists(os.path.join(self.repo_path, ".git", "MERGE_HEAD"))
+
+    def merge_head(self):
+        path = os.path.join(self.repo_path, ".git", "MERGE_HEAD")
+        with open(path, "r") as f:
+            commit_hash = f.read().strip()
+        return self.get_short_hash(commit_hash)

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -422,8 +422,10 @@ class GsBranchesMergeSelectedCommand(TextCommand, GitCommand):
 
         branches = self.interface.get_selected_branches(ignore_current_branch=True)
         branches_strings = self.interface.create_branches_strs(branches)
-        self.merge(branches_strings)
-        util.view.refresh_gitsavvy(self.view)
+        try:
+            self.merge(branches_strings)
+        finally:
+            util.view.refresh_gitsavvy(self.view)
 
 
 class GsBranchesFetchAndMergeCommand(TextCommand, GitCommand):
@@ -452,9 +454,11 @@ class GsBranchesFetchAndMergeCommand(TextCommand, GitCommand):
                 self.fetch(remote=branch[0], branch=branch[1])
 
         branches_strings = self.interface.create_branches_strs(branches)
-        self.merge(branches_strings)
-        self.view.window().status_message("Fetch and merge complete.")
-        util.view.refresh_gitsavvy(self.view)
+        try:
+            self.merge(branches_strings)
+            self.view.window().status_message("Fetch and merge complete.")
+        finally:
+            util.view.refresh_gitsavvy(self.view)
 
 
 class GsBranchesDiffBranchCommand(TextCommand, GitCommand):

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -95,6 +95,10 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
       [U] move commit before ...
       [w] show commit
 
+      ###########
+      ## OTHER ##
+      ###########
+
       [?]         toggle this help menu
       [tab]       transition to next dashboard
       [SHIFT-tab] transition to previous dashboard

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -168,14 +168,18 @@ class GsGithubCreatePullRequestCommand(WindowCommand, GitCommand, git_mixins.Git
             else:
                 status, secondary = self.get_branch_status()
                 if secondary:
-                    sublime.message_dialog(
-                        "Your current branch is different from its remote counterpart. %s" % secondary)
-                else:
-                    owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
-                    self.open_comparision_in_browser(
-                        owner,
-                        remote_branch.name
-                    )
+                    secondary = "\n".join(secondary)
+                    if "ahead" in secondary or "behind" in secondary:
+                        sublime.message_dialog(
+                            "Your current branch is different from its remote counterpart.\n" +
+                            secondary)
+                        return
+
+                owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
+                self.open_comparision_in_browser(
+                    owner,
+                    remote_branch.name
+                )
 
     def open_comparision_in_browser(self, owner, branch):
         base_remote = github.parse_remote(self.get_integrated_remote_url())

--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -151,17 +151,21 @@ class GsGitlabMergeRequestCommand(WindowCommand, GitCommand, git_mixins.GitLabRe
 #             remote_branch = self.get_active_remote_branch()
 #             if not remote_branch:
 #                 sublime.message_dialog("Unable to determine remote.")
-#             else:
-#                 status, secondary = self.get_branch_status()
-#                 if secondary:
-#                     sublime.message_dialog(
-#                         "Your current branch is different from its remote counterpart. %s" % secondary)
-#                 else:
-#                     owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
-#                     self.open_comparision_in_browser(
-#                         owner,
-#                         remote_branch.name
-#                     )
+#            else:
+#                status, secondary = self.get_branch_status()
+#                if secondary:
+#                    secondary = "\n".join(secondary)
+#                    if "ahead" in secondary or "behind" in secondary:
+#                        sublime.message_dialog(
+#                            "Your current branch is different from its remote counterpart.\n" +
+#                            secondary)
+#                        return
+
+#                owner = github.parse_remote(self.get_remotes()[remote_branch.remote]).owner
+#                self.open_comparision_in_browser(
+#                    owner,
+#                    remote_branch.name
+#                )
 
 #     def open_comparision_in_browser(self, owner, branch):
 #         base_remote = github.parse_remote(self.get_integrated_remote_url())


### PR DESCRIPTION
Rebase dashboard has commands `use version from your commit` and `use version from new base` to manage rebase conflicts. The main contribution of this PR is to bring those commands to the Status dashboard when there are merge conflicts.

<img width="328" alt="screen shot 2018-02-17 at 3 00 33 pm" src="https://user-images.githubusercontent.com/1690993/36345129-52747d84-13f3-11e8-8dff-cb8ba6a6af25.png">

This pr also improves active branch status when merging.
<img width="313" alt="screen shot 2018-02-17 at 3 03 31 pm" src="https://user-images.githubusercontent.com/1690993/36345152-bfe60590-13f3-11e8-96f9-1e6039d4a0d9.png">
<img width="314" alt="screen shot 2018-02-17 at 3 03 36 pm" src="https://user-images.githubusercontent.com/1690993/36345153-bff48552-13f3-11e8-9501-778e22a74288.png">
