### PR TITLE
Fix: tracking remote detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sublime Text 3 plugin providing the following features:
 - `git diff` view, allowing user to (un)stage hunks across all files
 - status, branch, tag, and rebase dashboards
 
-**Note:** Due to a bug present in earlier Git versions, GitSavvy only supports Git versions at or greater than 1.7.10.3.
+**Note:** GitSavvy only supports Git versions at or greater than 1.9.0.
 
 **Note:** Sublime Text 2 is not supported.  Also, GitSavvy takes advantage of certain features of ST3 that have bugs in earlier ST3 releases.  For the best experience, use the latest ST3 dev build.
 

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -1,4 +1,3 @@
-import re
 from collections import namedtuple
 import sublime
 
@@ -23,7 +22,11 @@ class BranchesMixin():
         Return a list of all local and remote branches.
         """
         stdout = self.git(
-            "branch", "-a", "-vv", "--no-abbrev", "--no-color", "--sort=-committerdate" if sort_by_recent else None)
+            "for-each-ref",
+            "--format=%(HEAD)%00%(refname)%00%(upstream)%00%(upstream:track)%00%(objectname)%00%(contents:subject)",
+            "--sort=-committerdate" if sort_by_recent else None,
+            "refs/heads",
+            "refs/remotes")
         return (branch
                 for branch in (self._parse_branch_line(self, line) for line in stdout.split("\n"))
                 if branch)
@@ -33,27 +36,17 @@ class BranchesMixin():
         line = line.strip()
         if not line:
             return None
+        head, ref, tracking_branch, tracking_status, commit_hash, commit_msg = line.split("\x00")
 
-        branch = r"([a-zA-Z0-9\-\_\/\.\-\u263a-\U0001f645]+(?<!\.lock)(?<!\/)(?<!\.))"
-        pattern = r"(\* )?(remotes/)?" + branch + r" +([0-9a-f]{40}) (\[([a-zA-Z0-9\-\_\/\.]+)(: ([^\]]+))?\] )?(.*)"
+        active = head == "*"
+        is_remote = ref.startswith("refs/remotes/")
 
-        match = re.match(pattern, line)
-        if not match:
-            return None
-
-        (is_active,
-         is_remote,
-         branch_name,
-         commit_hash,
-         _,
-         tracking_branch,
-         _,
-         tracking_status,
-         commit_msg
-         ) = match.groups()
-
-        active = bool(is_active)
-        remote = branch_name.split("/")[0] if is_remote else None
+        branch_name = ref[13:] if is_remote else ref[11:]
+        remote = ref[13:].split("/", 1)[0] if is_remote else None
+        tracking_branch = tracking_branch[13:]
+        if tracking_status:
+            # remove brackets
+            tracking_status = tracking_status[1:len(tracking_status) - 1]
 
         savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         enable_branch_descriptions = savvy_settings.get("enable_branch_descriptions")


### PR DESCRIPTION
The original branch status failed to parse the tracking remote correctly if the commit message starts with something like `[Fix] bla bla bla`.

```
(randymbpro)-git_mixins$ git branch -a -vv                                                                                         (pull_request)
* branch_status                                         f6a0ee0 [origin/branch_status] Fix: tracking remote detection
  dev                                                   f7de5a8 [origin/dev] [Internal] more typos
  exception                                             1c83450 [origin/exception] [Internal] more typos
  master                                                3c5b1ab [origin/master] Merge pull request #837 from divmain/release/2.16.7
  pull_request                                          3067f68 [origin/pull_request] Fix: gs_push_and_create_pull_request has renamed
  rebase_ref                                            730fce2 [Fix] branch relative regex
  test                                                  77a3e54 [randy3k/test: ahead 1, behind 1] [Internal] more typos
  remotes/origin/HEAD                                   -> origin/master
  remotes/origin/branch_status                          f6a0ee0 Fix: tracking remote detection
  remotes/origin/bugfix/amend-failure                   57b4a2e Tests: add a failing test for "first amend"
  remotes/origin/dev                                    f7de5a8 [Internal] more typos
  remotes/origin/exception                              1c83450 [Internal] more typos
  remotes/origin/gitlab-support                         8189f46 GitLab placeholder.
```
As shown in the above table, GItSavvy will wrongly identity `Fix` to be the tracking remote of `rebase_ref`. To fix the bug, the table is printed with a specific `--format` to garanteen that the tracking and message are seperated.