### PR TITLE
Refresh all GitSavvy view on branch checkout

### DIFF
--- a/common/util/view.py
+++ b/common/util/view.py
@@ -58,6 +58,30 @@ def get_is_view_of_type(view, typ):
 # GLOBAL #
 ##########
 
+def refresh_gitsavvy_interfaces(window,
+                                refresh_sidebar=False,
+                                refresh_status_bar=True,
+                                interface_reset_cursor=False):
+    """
+    Looks for GitSavvy interface views in the current window and refresh them.
+
+    Note that it only refresh visible views.
+    Other views will be refreshed when activated.
+    """
+    if window is None:
+        return
+
+    if refresh_sidebar:
+        window.run_command("refresh_folder_list")
+    if refresh_status_bar:
+        window.active_view().run_command("gs_update_status_bar")
+
+    for group in range(window.num_groups()):
+        view = window.active_view_in_group(group)
+        if view.settings().get("git_savvy.interface") is not None:
+            view.run_command("gs_interface_refresh", {"nuke_cursors": interface_reset_cursor})
+
+
 def refresh_gitsavvy(view, refresh_sidebar=False, refresh_status_bar=True,
                      interface_reset_cursor=False):
     """

--- a/core/commands/checkout.py
+++ b/core/commands/checkout.py
@@ -38,7 +38,7 @@ class GsCheckoutBranchCommand(WindowCommand, GitCommand):
 
         self.git("checkout", branch)
         self.window.status_message("Checked out `{}` branch.".format(branch))
-        util.view.refresh_gitsavvy(self.window.active_view(), refresh_sidebar=True)
+        util.view.refresh_gitsavvy_interfaces(self.window, refresh_sidebar=True)
 
 
 class GsCheckoutNewBranchCommand(WindowCommand, GitCommand):
@@ -68,10 +68,9 @@ class GsCheckoutNewBranchCommand(WindowCommand, GitCommand):
             branch_name,
             self.base_branch if self.base_branch else None)
         self.window.status_message("Created and checked out `{}` branch.".format(branch_name))
-        util.view.refresh_gitsavvy(
-            self.window.active_view(),
-            refresh_sidebar=True,
-            interface_reset_cursor=True)
+        util.view.refresh_gitsavvy_interfaces(self.window,
+                                              refresh_sidebar=True,
+                                              interface_reset_cursor=True)
 
 
 class GsCheckoutRemoteBranchCommand(WindowCommand, GitCommand):
@@ -119,11 +118,9 @@ class GsCheckoutRemoteBranchCommand(WindowCommand, GitCommand):
         self.git("checkout", "-b", branch_name, "--track", self.remote_branch)
         self.window.status_message(
             "Checked out `{}` as local branch `{}`.".format(self.remote_branch, branch_name))
-        util.view.refresh_gitsavvy(
-            self.window.active_view(),
-            refresh_sidebar=True,
-            interface_reset_cursor=True
-        )
+        util.view.refresh_gitsavvy_interfaces(self.window,
+                                              refresh_sidebar=True,
+                                              interface_reset_cursor=True)
 
 
 class GsCheckoutCurrentFileCommand(WindowCommand, GitCommand):


### PR DESCRIPTION
Proof of concept implementation of #835.

Add a `refresh_all_visible_views` method.
It iterates through all the current window groups and refresh the active view of the group.