### PR TITLE
Fix: filter branch HEAD

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -29,7 +29,7 @@ class BranchesMixin():
             "refs/remotes")
         return (branch
                 for branch in (self._parse_branch_line(self, line) for line in stdout.split("\n"))
-                if branch)
+                if branch and branch.name != "HEAD")
 
     @staticmethod
     def _parse_branch_line(self, line):


### PR DESCRIPTION
`for-each-ref` may list `HEAD` as one of the branches.

Before
<img width="237" alt="screen shot 2018-03-03 at 12 02 45 am" src="https://user-images.githubusercontent.com/1690993/36930777-3fd08d84-1e76-11e8-9035-f4513f716e3f.png">

After
<img width="263" alt="screen shot 2018-03-03 at 12 02 55 am" src="https://user-images.githubusercontent.com/1690993/36930778-4462cf74-1e76-11e8-9f7c-298d0b4745bc.png">
