### PR TITLE
Fix: use urllib.parse.quote_plus

### DIFF
--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -184,17 +184,17 @@ class GsGithubCreatePullRequestCommand(WindowCommand, GitCommand, git_mixins.Git
 
     def open_comparision_in_browser(self, owner, branch):
         base_remote = github.parse_remote(self.get_integrated_remote_url())
-        url = base_remote.url
+        remote_url = base_remote.url
         base_owner = base_remote.owner
         base_branch = self.get_integrated_branch_name()
-
-        open_in_browser(urllib.urlencode("{}/compare/{}:{}...{}:{}?expand=1".format(
-            url,
+        url = "{}/compare/{}:{}...{}:{}?expand=1".format(
+            remote_url,
             base_owner,
-            base_branch,
+            urllib.parse.quote_plus(base_branch),
             owner,
-            branch
-        )))
+            urllib.parse.quote_plus(branch)
+        )
+        open_in_browser(url)
 
 
 class GsGithubPushAndCreatePullRequestCommand(GsPushToBranchNameCommand):

--- a/github/github.py
+++ b/github/github.py
@@ -96,7 +96,7 @@ def open_file_in_browser(rel_path, remote, commit_hash, start_line=None, end_lin
         lines=line_numbers
     )
 
-    open_in_browser(urllib.urlencode(url))
+    open_in_browser(url)
 
 
 def open_repo(remote):

--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -170,18 +170,17 @@ class GsGitlabMergeRequestCommand(WindowCommand, GitCommand, git_mixins.GitLabRe
 
 #     def open_comparision_in_browser(self, owner, branch):
 #         base_remote = github.parse_remote(self.get_integrated_remote_url())
-#         url = base_remote.url
+#         remote_url = base_remote.url
 #         base_owner = base_remote.owner
 #         base_branch = self.get_integrated_branch_name()
-
-#         open_in_browser(urllib.urlencode("{}/compare/{}:{}...{}:{}?expand=1".format(
-#             url,
+#         url = "{}/compare/{}:{}...{}:{}?expand=1".format(
+#             remote_url,
 #             base_owner,
-#             base_branch,
+#             urllib.parse.quote_plus(base_branch),
 #             owner,
-#             branch
-#         )))
-
+#             urllib.parse.quote_plus(branch)
+#         )
+#         open_in_browser(url)
 
 # class GsPushAndCreateMergeRequestCommand(GsPushToBranchNameCommand):
 

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -98,7 +98,7 @@ def open_file_in_browser(rel_path, remote, commit_hash, start_line=None, end_lin
         lines=line_numbers
     )
 
-    open_in_browser(urllib.urlencode(url))
+    open_in_browser(url)
 
 
 def open_repo(remote):


### PR DESCRIPTION
revert some of the changes in #883 

It turns out `urllib.urlencode` is a wrong function to use and we should not encode the entire url.