### PR TITLE
Fix: use check-ref-format to check branch name validity

### DIFF
--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -97,3 +97,7 @@ class BranchesMixin():
             commit_hash
         ).strip().split("\n")
         return [branch.strip() for branch in branches]
+
+    def validate_branch_name(self, branch):
+        ref = "refs/heads/{}".format(branch)
+        return self.git("check-ref-format", "--branch", ref, throw_on_stderr=False).strip()


### PR DESCRIPTION
Instead of using a regular expression to validate branch name, use the git command `check-ref-format` to validate it. It should give a better result than using a regular expression.