### PR TITLE
Enhancement: rename `git: add (edit)` command

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -48,15 +48,15 @@
     },
 
     //////////////////
-    // GIT-ADD VIEW //
+    // STAGE_DIFF VIEW //
     //////////////////
 
     {
         "keys": ["ctrl+enter"],
-        "command": "gs_add_edit_commit",
+        "command": "gs_stage_diff_apply",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.git_add_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.git_stage_diff_view", "operator": "equal", "operand": true }
         ]
     },
 

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -48,15 +48,15 @@
     },
 
     //////////////////
-    // GIT-ADD VIEW //
+    // STAGE_DIFF VIEW //
     //////////////////
 
     {
         "keys": ["super+enter"],
-        "command": "gs_add_edit_commit",
+        "command": "gs_stage_diff_apply",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.git_add_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.git_stage_diff_view", "operator": "equal", "operand": true }
         ]
     },
 

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -49,15 +49,15 @@
     },
 
     //////////////////
-    // GIT-ADD VIEW //
+    // STAGE_DIFF VIEW //
     //////////////////
 
     {
         "keys": ["ctrl+enter"],
-        "command": "gs_add_edit_commit",
+        "command": "gs_stage_diff_apply",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.git_add_view", "operator": "equal", "operand": true }
+            { "key": "setting.git_savvy.git_stage_diff_view", "operator": "equal", "operand": true }
         ]
     },
 

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -21,8 +21,8 @@
         "command": "gs_quick_stage"
     },
     {
-        "caption": "git: add (edit)",
-        "command": "gs_add_edit"
+        "caption": "git: edit and stage diff",
+        "command": "gs_stage_diff"
     },
     {
         "caption": "git: quick commit",

--- a/core/commands/__init__.py
+++ b/core/commands/__init__.py
@@ -28,7 +28,7 @@ from .cherry_pick import *
 from .revert import *
 from .tag import *
 from .show_file_at_commit import *
-from .git_add import *
+from .stage_diff import *
 from .navigate import *
 from .rebase_interactive import *
 from .fixup import *

--- a/core/commands/stage_diff.py
+++ b/core/commands/stage_diff.py
@@ -13,10 +13,10 @@ from ..git_command import GitCommand
 from ..exceptions import GitSavvyError
 
 
-TITLE = "GIT-ADD: {}"
+TITLE = "STAGE-DIFF: {}"
 
 
-class GsAddEditCommand(WindowCommand, GitCommand):
+class GsStageDiffCommand(WindowCommand, GitCommand):
 
     """
     Create a new view to display the project's unstaged changes.
@@ -26,21 +26,17 @@ class GsAddEditCommand(WindowCommand, GitCommand):
         sublime.set_timeout_async(lambda: self.run_async(**kwargs), 0)
 
     def run_async(self):
-        git_add_view = util.view.get_scratch_view(self, "git_add", read_only=False)
-        git_add_view.set_name(TITLE.format(os.path.basename(self.repo_path)))
-        git_add_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime_syntax")
-        git_add_view.settings().set("git_savvy.repo_path", self.repo_path)
+        stage_diff_view = util.view.get_scratch_view(self, "git_stage_diff", read_only=False)
+        stage_diff_view.set_name(TITLE.format(os.path.basename(self.repo_path)))
+        stage_diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime_syntax")
+        stage_diff_view.settings().set("git_savvy.repo_path", self.repo_path)
 
-        self.window.focus_view(git_add_view)
-        git_add_view.sel().clear()
-        git_add_view.run_command("gs_add_edit_refresh")
-
-        super_key = "SUPER" if sys.platform == "darwin" else "CTRL"
-        message = "Press {}-Enter to apply the diff.  Close the window to cancel.".format(super_key)
-        sublime.message_dialog(message)
+        self.window.focus_view(stage_diff_view)
+        stage_diff_view.sel().clear()
+        stage_diff_view.run_command("gs_stage_diff_refresh")
 
 
-class GsAddEditRefreshCommand(TextCommand, GitCommand):
+class GsStageDiffRefreshCommand(TextCommand, GitCommand):
 
     """
     Refresh the view with the latest unstaged changes.
@@ -67,10 +63,14 @@ class GsAddEditRefreshCommand(TextCommand, GitCommand):
                 return
             raise err
 
-        self.view.run_command("gs_replace_view_text", {"text": stdout})
+        super_key = "SUPER" if sys.platform == "darwin" else "CTRL"
+        message = "Press {}-Enter to apply the diff.  Close the window to cancel.".format(super_key)
+        content = message + "\n\n" + stdout
+
+        self.view.run_command("gs_replace_view_text", {"text": content})
 
 
-class GsAddEditCommitCommand(TextCommand, GitCommand):
+class GsStageDiffApplyCommand(TextCommand, GitCommand):
 
     """
     Apply the commit as it is presented in the view to the index. Then close the view.

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -41,11 +41,16 @@ You also have the option of staging all unstaged files (excluding untracked file
 
 ## `git: diff`
 
-This command will open a special diff view.  Output from `git diff` will be displayed.  If you position your cursor over a hunk and press `SUPER-Enter` (`CTRL-Enter` in Windows), that hunk will be staged.
+This command will open a special diff view.  Output from `git diff` will be displayed.  If you position your cursor over a hunk and press `SUPER-Enter` (`CTRL-Enter` in Windows/Linux), that hunk will be staged.
 
 Use `o` to open the file at the beginning of the hunk.  Pressing `s` will toggle whether the diff ignores whitespice changes.  Pressing `w` will toggle whether the `--word-diff` mode is used.  And remember that you can not stage anything if either of these modes are enabled.
 
 
 ## `git: diff cached`
 
-This command functions similarly to the above.  However, it displays the output of `git diff --cached` and, when you press `SUPER-Enter` (`CTRL-Enter` in Windows) over a hunk, that hunk will be _removed_ from the index.
+This command functions similarly to the above.  However, it displays the output of `git diff --cached` and, when you press `SUPER-Enter` (`CTRL-Enter` in Windows/Linux) over a hunk, that hunk will be _removed_ from the index.
+
+
+## `git: edit and stage diff`
+
+This command displays an editable view of `git diff`, when you press `SUPER-Enter` (`CTRL-Enter` in Windows/Linux). The whole diff content will be applied to the index.


### PR DESCRIPTION
Per https://github.com/divmain/GitSavvy/pull/889#issuecomment-372092537, 
rename `git: add (edit)` command to `git: edit and stage diff`.

Also, close #888 by showing the hint at the top of the diff instead of showing a popup.
<img width="759" alt="screen shot 2018-03-11 at 2 48 50 pm" src="https://user-images.githubusercontent.com/1690993/37257147-6b7eedc4-253b-11e8-9cb6-529f2ec4a713.png">
