### PR TITLE
Add Key Binding setting shortcut

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -6,6 +6,13 @@
             "base_file": "${packages}/GitSavvy/GitSavvy.sublime-settings",
             "default": "// Settings in here override those in \"GitSavvy/GitSavvy.sublime-settings\",\n\n{\n\t$0\n}\n"}
     },
+    {
+        "caption": "Preferences: GitSavvy Key Bindings",
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/GitSavvy/Default (${platform}).sublime-keymap"
+        }
+    },
 
     {
         "caption": "git: diff current file inline",

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -8,7 +8,7 @@
     },
     {
         "caption": "Preferences: GitSavvy Key Bindings",
-        "command": "edit_settings",
+        "command": "gs_edit_settings",
         "args": {
             "base_file": "${packages}/GitSavvy/Default (${platform}).sublime-keymap"
         }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,6 +17,12 @@
                                     "base_file": "${packages}/GitSavvy/GitSavvy.sublime-settings",
                                     "default": "// Settings in here override those in \"GitSavvy/GitSavvy.sublime-settings\",\n\n{\n\t$0\n}\n"
                                 }
+                            }, {
+                                "caption": "Key Bindings",
+                                "command": "edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/GitSavvy/Default (${platform}).sublime-keymap"
+                                }
                             }
                         ]
                     }

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -1,5 +1,5 @@
 import sublime
-from sublime_plugin import EventListener
+from sublime_plugin import EventListener, WindowCommand
 
 from . import util
 
@@ -51,3 +51,13 @@ class KeyboardSettingsListener(EventListener):
                 w.focus_group(0)
                 w.run_command("open_file", {"file": "${packages}/GitSavvy/Default.sublime-keymap"})
                 w.focus_group(1)
+
+
+class GsEditSettingsCommand(WindowCommand):
+    """
+    For some reasons, the command palette doesn't trigger `on_post_window_command` for
+    dev version of Sublime Text. The command palette would call `gs_edit_settings` and
+    subsequently trigger `on_post_window_command`.
+    """
+    def run(self, **kwargs):
+        self.window.run_command("edit_settings", kwargs)

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -1,3 +1,4 @@
+import sublime
 from sublime_plugin import EventListener
 
 from . import util
@@ -39,3 +40,14 @@ class GitCommandFromTerminal(EventListener):
             name = view.file_name().split("/")[-1]
             if name in git_view_syntax.keys():
                 view.run_command("save")
+
+
+class KeyboardSettingsListener(EventListener):
+    def on_post_window_command(self, window, command, args):
+        if command == "edit_settings":
+            base = args.get("base_file", "")
+            if base.endswith("sublime-keymap") and "/GitSavvy/Default" in base:
+                w = sublime.active_window()
+                w.focus_group(0)
+                w.run_command("open_file", {"file": "${packages}/GitSavvy/Default.sublime-keymap"})
+                w.focus_group(1)


### PR DESCRIPTION
Many Thanks to OdatNurd[1]
https://forum.sublimetext.com/t/open-key-sublime-keymap-with-edit-settings-with-specific-platform-in-mind/35604/3?u=stoivo

fix #884

[1] https://forum.sublimetext.com/u/OdatNurd

Two tabs on the left side
![screen shot 2018-03-19 at 21 08 45](https://user-images.githubusercontent.com/3492040/37619895-0bf09e94-2bbb-11e8-8231-84a0cde0cbca.png)

Should this be merged into `dev` or should to merge this one in to `release/2.17.0`?