### PR TITLE
refactoring GitSavvy settings and project-wise settings

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,7 +4,12 @@
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/GitSavvy/GitSavvy.sublime-settings",
-            "default": "// Settings in here override those in \"GitSavvy/GitSavvy.sublime-settings\",\n\n{\n\t$0\n}\n"}
+            "default": "// Settings in here override those in \"GitSavvy/GitSavvy.sublime-settings\",\n\n{\n\t$0\n}\n"
+        }
+    },
+    {
+        "caption": "Preferences: GitSavvy Project Settings",
+        "command": "gs_edit_project_settings"
     },
     {
         "caption": "Preferences: GitSavvy Key Bindings",

--- a/GitSavvy.sublime-project
+++ b/GitSavvy.sublime-project
@@ -1,27 +1,37 @@
 {
-    "folders": [
-        {
-            "path": ".",
-            "folder_exclude_patterns": [
-                ".git",
-                "__pycache__"
-            ]
-        }
-    ],
-    "settings": {
-        "rulers": [100, 120],
-        "tab_size": 4,
-        "translate_tabs_to_spaces": true
-    },
-    "build_systems":
-    [
-        {
-            "name": "Reload GitSavvy",
-            "target": "gs_reload_modules_debug"
-        },
-        {
-            "name": "Test GitSavvy",
-            "target": "unit_testing_current_package"
-        }
-    ]
+	"build_systems":
+	[
+		{
+			"name": "Reload GitSavvy",
+			"target": "gs_reload_modules_debug"
+		},
+		{
+			"name": "Test GitSavvy",
+			"target": "unit_testing_current_package"
+		}
+	],
+	"folders":
+	[
+		{
+			"folder_exclude_patterns":
+			[
+				".git",
+				"__pycache__"
+			],
+			"path": "."
+		}
+	],
+	"settings":
+	{
+		"GitSavvy":
+		{
+		},
+		"rulers":
+		[
+			100,
+			120
+		],
+		"tab_size": 4,
+		"translate_tabs_to_spaces": true
+	}
 }

--- a/GitSavvy.sublime-project
+++ b/GitSavvy.sublime-project
@@ -1,4 +1,7 @@
 {
+	"GitSavvy":
+	{
+	},
 	"build_systems":
 	[
 		{
@@ -23,9 +26,6 @@
 	],
 	"settings":
 	{
-		"GitSavvy":
-		{
-		},
 		"rulers":
 		[
 			100,

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -52,6 +52,11 @@
     "github_per_page_max" : 100,
 
     /*
+    maximum number of items per page when requesting from gitlab
+    */
+    "gitlab_per_page_max" : 100,
+
+    /*
         Change this to "full" to display a full diff for the current commit
         when writing a commit message.
 

--- a/common/commands/debug.py
+++ b/common/commands/debug.py
@@ -2,13 +2,10 @@
 Sublime commands related to development and debugging.
 """
 
-import sys
-import urllib
-
-import sublime
 from sublime_plugin import WindowCommand
 
 from ..util import debug, reload
+from ...core.settings import GitSavvySettings
 
 REPORT_URL_TEMPLATE = "https://github.com/divmain/GitSavvy/issues/new?{q}"
 
@@ -23,8 +20,7 @@ class GsReloadModulesDebug(WindowCommand):
         reload.reload_plugin()
 
     def is_visible(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        return savvy_settings.get("dev_mode")
+        return GitSavvySettings().get("dev_mode")
 
 
 class GsStartLoggingCommand(WindowCommand):

--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -1,5 +1,6 @@
 import sublime
 from sublime_plugin import TextCommand
+from ...core.settings import GitSavvySettings
 
 
 class GsInsertTextAtCursorCommand(TextCommand):
@@ -64,7 +65,7 @@ class GsHandleVintageousCommand(TextCommand):
     """
 
     def run(self, edit):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        savvy_settings = GitSavvySettings()
         if savvy_settings.get("vintageous_friendly", False) is True:
             self.view.settings().set("git_savvy.vintageous_friendly", True)
             if savvy_settings.get("vintageous_enter_insert_mode", False) is True:
@@ -79,6 +80,6 @@ class GsHandleArrowKeysCommand(TextCommand):
     """
 
     def run(self, edit):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+        savvy_settings = GitSavvySettings()
         if savvy_settings.get("arrow_keys_navigation", False) is True:
             self.view.settings().set("git_savvy.arrow_keys_navigation", True)

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -77,10 +77,8 @@ class GsEditProjectSettingsCommand(WindowCommand):
 
         if project_data is None:
             project_data = {}
-        if "settings" not in project_data:
-            project_data["settings"] = {"GitSavvy": {}}
-        if "GitSavvy" not in project_data["settings"]:
-            project_data["settings"]["GitSavvy"] = {}
+        if "GitSavvy" not in project_data:
+            project_data["GitSavvy"] = {}
 
         self.window.set_project_data(project_data)
 

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -73,16 +73,18 @@ class GsEditProjectSettingsCommand(WindowCommand):
         project_file_name = self.window.project_file_name()
         project_data = self.window.project_data()
         if not project_file_name or project_data is None:
-            sublime.error_message("no project data found.")
+            sublime.error_message("No project data found.")
 
-        if project_data and "settings" not in project_data:
+        if project_data is None:
+            project_data = {}
+        if "settings" not in project_data:
             project_data["settings"] = {"GitSavvy": {}}
         if "GitSavvy" not in project_data["settings"]:
             project_data["settings"]["GitSavvy"] = {}
 
         self.window.set_project_data(project_data)
 
-        self.window.run_command("edit_settings", {
+        sublime.set_timeout(lambda: self.window.run_command("edit_settings", {
             "user_file": project_file_name,
             "base_file": "${packages}/GitSavvy/GitSavvy.sublime-settings"
-        })
+        }), 100)

--- a/common/global_events.py
+++ b/common/global_events.py
@@ -61,3 +61,28 @@ class GsEditSettingsCommand(WindowCommand):
     """
     def run(self, **kwargs):
         self.window.run_command("edit_settings", kwargs)
+
+
+class GsEditProjectSettingsCommand(WindowCommand):
+    """
+    For some reasons, the command palette doesn't trigger `on_post_window_command` for
+    dev version of Sublime Text. The command palette would call `gs_edit_settings` and
+    subsequently trigger `on_post_window_command`.
+    """
+    def run(self):
+        project_file_name = self.window.project_file_name()
+        project_data = self.window.project_data()
+        if not project_file_name or project_data is None:
+            sublime.error_message("no project data found.")
+
+        if project_data and "settings" not in project_data:
+            project_data["settings"] = {"GitSavvy": {}}
+        if "GitSavvy" not in project_data["settings"]:
+            project_data["settings"]["GitSavvy"] = {}
+
+        self.window.set_project_data(project_data)
+
+        self.window.run_command("edit_settings", {
+            "user_file": project_file_name,
+            "base_file": "${packages}/GitSavvy/GitSavvy.sublime-settings"
+        })

--- a/common/ui.py
+++ b/common/ui.py
@@ -6,6 +6,7 @@ import sublime
 from sublime_plugin import TextCommand
 
 from . import util
+from ..core.settings import GitSavvySettings
 
 
 interfaces = {}
@@ -73,7 +74,6 @@ class Interface():
 
     def create_view(self, repo_path):
         window = sublime.active_window()
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         self.view = window.new_file()
 
         self.view.settings().set("git_savvy.repo_path", repo_path)
@@ -81,7 +81,7 @@ class Interface():
         self.view.settings().set("git_savvy.{}_view".format(self.interface_type), True)
         self.view.settings().set("git_savvy.tabbable", True)
         self.view.settings().set("git_savvy.interface", self.interface_type)
-        self.view.settings().set("git_savvy.help_hidden", savvy_settings.get("hide_help_menu"))
+        self.view.settings().set("git_savvy.help_hidden", GitSavvySettings().get("hide_help_menu"))
         self.view.set_syntax_file(self.syntax_file)
         self.view.set_scratch(True)
         self.view.set_read_only(self.read_only)

--- a/common/util/actions.py
+++ b/common/util/actions.py
@@ -1,18 +1,18 @@
 import sublime
+from ...core.settings import GitSavvySettings
 
 
 def destructive(description):
     def decorator(fn):
 
         def wrapped_fn(*args, **kwargs):
-            settings = sublime.load_settings("GitSavvy.sublime-settings")
-            if settings.get("prompt_before_destructive_action"):
+            if GitSavvySettings().get("prompt_before_destructive_action"):
                 message = (
                     "You are about to {desc}.  "
                     "This is a destructive action.  \n\n"
                     "Are you SURE you want to do this?  \n\n"
                     "(you can disable this prompt in "
-                    "GitSavvy.sublime-settings)").format(desc=description)
+                    "GitSavvy settings)").format(desc=description)
                 if not sublime.ok_cancel_dialog(message):
                     return
 

--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -2,8 +2,9 @@ import functools
 import json
 import pprint as _pprint
 
-import sublime
 from contextlib import contextmanager
+
+from ...core.settings import GitSavvySettings
 
 _log = []
 enabled = False
@@ -125,7 +126,7 @@ def pprint(*args, **kwargs):
 
 
 def get_trace_tags():
-    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
+    savvy_settings = GitSavvySettings()
     if savvy_settings.get("dev_mode"):
         return savvy_settings.get("dev_trace", [])
     else:

--- a/common/util/view.py
+++ b/common/util/view.py
@@ -1,6 +1,7 @@
 import bisect
 
 import sublime
+from ...core.settings import GitSavvySettings
 
 
 ##############
@@ -171,5 +172,5 @@ def get_instance_after_pt(view, pt, pattern):
 def disable_other_plugins(view):
     # Disable key-bindings for Vitageous
     # https://github.com/guillermooo/Vintageous/wiki/Disabling
-    if sublime.load_settings("GitSavvy.sublime-settings").get("vintageous_friendly", False) is False:
+    if GitSavvySettings().get("vintageous_friendly", False) is False:
         view.settings().set("__vi_external_disable", False)

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -97,8 +97,7 @@ class GsBlameCurrentFileCommand(LogMixin, TextCommand, GitCommand):
             100)
 
     def log(self, **kwargs):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        follow = savvy_settings.get("blame_follow_rename")
+        follow = self.savvy_settings.get("blame_follow_rename")
         kwargs["follow"] = follow
         return super().log(**kwargs)
 
@@ -169,14 +168,12 @@ class GsBlameRefreshCommand(BlameMixin, TextCommand, GitCommand):
                         (0, cursor_layout[1] - yoffset), animate=False), 100)
 
     def get_content(self, ignore_whitespace=False, detect_options=None, commit_hash=None):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-
         if commit_hash:
             # git blame does not follow file name changes like git log, therefor we
             # need to look at the log first too see if the file has changed names since
             # selected commit. I would not be surprised if this brakes in some special cases
             # like rebased or multimerged commits
-            follow = savvy_settings.get("blame_follow_rename")
+            follow = self.savvy_settings.get("blame_follow_rename")
             filename_at_commit = self.filename_at_commit(self.file_path, commit_hash, follow=follow)
         else:
             filename_at_commit = self.file_path
@@ -358,8 +355,7 @@ class GsBlameActionCommand(BlameMixin, PanelActionMixin, TextCommand, GitCommand
         self.view.window().run_command("gs_show_commit", {"commit_hash": commit_hash})
 
     def blame_neighbor(self, position, selected=False):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        follow = savvy_settings.get("blame_follow_rename")
+        follow = self.savvy_settings.get("blame_follow_rename")
 
         if position == "newer" and selected:
             raise Exception("blame a commit after selected commit is confusing")

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -6,6 +6,7 @@ from sublime_plugin import EventListener
 
 from ..git_command import GitCommand
 from ...common import util
+from ...core.settings import SettingsMixin
 
 
 COMMIT_HELP_TEXT_EXTRA = """##
@@ -59,8 +60,7 @@ class GsCommitCommand(WindowCommand, GitCommand):
         settings.set("git_savvy.commit_view.amend", amend)
         settings.set("git_savvy.repo_path", repo_path)
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        if savvy_settings.get("use_syntax_for_commit_editmsg"):
+        if self.savvy_settings.get("use_syntax_for_commit_editmsg"):
             syntax_file = util.file.get_syntax_for_file("COMMIT_EDITMSG")
             view.set_syntax_file(syntax_file)
         else:
@@ -68,12 +68,12 @@ class GsCommitCommand(WindowCommand, GitCommand):
 
         view.run_command("gs_handle_vintageous")
 
-        commit_on_close = savvy_settings.get("commit_on_close")
+        commit_on_close = self.savvy_settings.get("commit_on_close")
         settings.set("git_savvy.commit_on_close", commit_on_close)
 
         title = COMMIT_TITLE.format(os.path.basename(repo_path))
         view.set_name(title)
-        if commit_on_close or not savvy_settings.get("prompt_on_abort_commit"):
+        if commit_on_close or not self.savvy_settings.get("prompt_on_abort_commit"):
             view.set_scratch(True)
         view.run_command("gs_commit_initialize_view")
 
@@ -87,10 +87,9 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
 
     def run(self, edit):
         merge_msg_path = os.path.join(self.repo_path, ".git", "MERGE_MSG")
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
 
         help_text = (COMMIT_HELP_TEXT_ALT
-                     if savvy_settings.get("commit_on_close")
+                     if self.savvy_settings.get("commit_on_close")
                      else COMMIT_HELP_TEXT)
         self.view.settings().set("git_savvy.commit_view.help_text", help_text)
 
@@ -105,7 +104,7 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
         else:
             initial_text = help_text
 
-        commit_help_extra_file = savvy_settings.get("commit_help_extra_file") or ".commit_help"
+        commit_help_extra_file = self.savvy_settings.get("commit_help_extra_file") or ".commit_help"
         commit_help_extra_path = os.path.join(self.repo_path, commit_help_extra_file)
         if os.path.exists(commit_help_extra_path):
             with util.file.safe_open(commit_help_extra_path, "r", encoding="utf-8") as f:
@@ -116,12 +115,12 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
             "--no-color"
         ]
 
-        show_commit_diff = savvy_settings.get("show_commit_diff")
+        show_commit_diff = self.savvy_settings.get("show_commit_diff")
         # for backward compatibility, check also if show_commit_diff is True
         if show_commit_diff is True or show_commit_diff == "full":
             git_args.append("--patch")
 
-        show_diffstat = savvy_settings.get("show_diffstat")
+        show_diffstat = self.savvy_settings.get("show_diffstat")
         if show_commit_diff == "stat" or (show_commit_diff == "full" and show_diffstat):
             git_args.append("--stat")
 
@@ -140,7 +139,7 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
         })
 
 
-class GsPedanticEnforceEventListener(EventListener):
+class GsPedanticEnforceEventListener(EventListener, SettingsMixin):
     """
     Set regions to worn for Pedantic commits
     """
@@ -149,21 +148,20 @@ class GsPedanticEnforceEventListener(EventListener):
         if 'make_commit' not in view.settings().get('syntax'):
             return
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        if not savvy_settings.get('pedantic_commit'):
+        if not self.savvy_settings.get('pedantic_commit'):
             return
 
         self.view = view
-        self.first_line_limit = savvy_settings.get('pedantic_commit_first_line_length')
-        self.body_line_limit = savvy_settings.get('pedantic_commit_message_line_length')
-        self.warning_length = savvy_settings.get('pedantic_commit_warning_length')
+        self.first_line_limit = self.savvy_settings.get('pedantic_commit_first_line_length')
+        self.body_line_limit = self.savvy_settings.get('pedantic_commit_message_line_length')
+        self.warning_length = self.savvy_settings.get('pedantic_commit_warning_length')
 
         self.comment_start_region = self.view.find_all('^#')
         self.first_comment_line = None
         if self.comment_start_region:
             self.first_comment_line = self.view.rowcol(self.comment_start_region[0].begin())[0]
 
-        if savvy_settings.get('pedantic_commit_ruler'):
+        if self.savvy_settings.get('pedantic_commit_ruler'):
             self.view.settings().set("rulers", self.find_rulers())
 
         waring, illegal = self.find_too_long_lines()
@@ -260,8 +258,7 @@ class GsCommitViewDoCommitCommand(TextCommand, GitCommand):
 
         include_unstaged = self.view.settings().get("git_savvy.commit_view.include_unstaged")
 
-        show_panel_overrides = \
-            sublime.load_settings("GitSavvy.sublime-settings").get("show_panel_for")
+        show_panel_overrides = self.savvy_settings.get("show_panel_for")
 
         self.git(
             "commit",

--- a/core/commands/commit_compare.py
+++ b/core/commands/commit_compare.py
@@ -44,8 +44,7 @@ class GsCompareCommitCommand(WindowCommand, GitCommand):
         view.run_command("gs_handle_arrow_keys")
 
     def get_graph_args(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        args = savvy_settings.get("git_graph_args")
+        args = self.savvy_settings.get("git_graph_args")
         if self._file_path:
             file_path = self.get_rel_path(self._file_path)
             args = args + ["--", file_path]

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -47,7 +47,6 @@ class GsDiffCommand(WindowCommand, GitCommand):
             "-" if base_commit is None else "--" + base_commit,
             file_path or repo_path
         )
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
 
         if view_key in diff_views and diff_views[view_key] in sublime.active_window().views():
             diff_view = diff_views[view_key]
@@ -63,7 +62,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
             settings.set("git_savvy.diff_view.show_word_diff", False)
             settings.set("git_savvy.diff_view.base_commit", base_commit)
             settings.set("git_savvy.diff_view.target_commit", target_commit)
-            settings.set("git_savvy.diff_view.show_diffstat", savvy_settings.get("show_diffstat", True))
+            settings.set("git_savvy.diff_view.show_diffstat", self.savvy_settings.get("show_diffstat", True))
             settings.set("git_savvy.diff_view.disable_stage", disable_stage)
             diff_view.set_name(title)
             diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")

--- a/core/commands/flow.py
+++ b/core/commands/flow.py
@@ -34,8 +34,7 @@ class FlowCommon(WindowCommand, GitCommand):
             self.window.show_quick_panel([INIT_REQUIRED_MSG], None)
 
     def is_visible(self, **kwargs):
-        gitsavvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        return gitsavvy_settings.get("show_git_flow_commands") or False
+        return self.savvy_settings.get("show_git_flow_commands") or False
 
     def _generic_select(self, help_text, options, callback,
                         no_opts="There are no branches available"):

--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -24,7 +24,7 @@ GIT_URL = "Enter git url:"
 views_with_offer_made = set()
 
 
-class GsOfferInit(WindowCommand):
+class GsOfferInit(WindowCommand, GitCommand):
 
     """
     If a git command fails indicating no git repo was found, this
@@ -34,8 +34,7 @@ class GsOfferInit(WindowCommand):
     """
 
     def run(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        if savvy_settings.get("disable_git_init_prompt"):
+        if self.savvy_settings.get("disable_git_init_prompt"):
             return
 
         active_view_id = self.window.active_view().id()

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -77,8 +77,7 @@ class GsInlineDiffCommand(WindowCommand, GitCommand):
                 file_binary.decode("latin-1")
                 diff_view.settings().set("git_savvy.inline_diff.encoding", "latin-1")
             except UnicodeDecodeError as unicode_err:
-                savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-                fallback_encoding = savvy_settings.get("fallback_encoding")
+                fallback_encoding = self.savvy_settings.get("fallback_encoding")
                 diff_view.settings().set("git_savvy.inline_diff.encoding", fallback_encoding)
 
         self.window.focus_view(diff_view)
@@ -92,7 +91,7 @@ class GsInlineDiffCommand(WindowCommand, GitCommand):
         additional inline-diff-related style rules added.  Save this color scheme
         to disk and set it as the target view's active color scheme.
         """
-        colors = sublime.load_settings("GitSavvy.sublime-settings").get("colors")
+        colors = self.savvy_settings.get("colors")
 
         original_color_scheme = target_view.settings().get("color_scheme")
         if original_color_scheme.endswith(".tmTheme"):
@@ -148,10 +147,9 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
     def run(self, edit):
         file_path = self.file_path
         in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         ignore_eol_arg = (
             "--ignore-space-at-eol"
-            if savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
+            if self.savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
             else None
         )
 
@@ -186,7 +184,7 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
         self.view.replace(edit, sublime.Region(0, self.view.size()), inline_diff_contents)
 
         if cursors:
-            if (row, col) == (0, 0) and savvy_settings.get("inline_diff_auto_scroll", False):
+            if (row, col) == (0, 0) and self.savvy_settings.get("inline_diff_auto_scroll", False):
                 self.view.run_command("gs_inline_diff_navigate_hunk")
             else:
                 self.view.sel().clear()
@@ -360,10 +358,9 @@ class GsInlineDiffStageOrResetBase(TextCommand, GitCommand):
 
     def run_async(self, reset=False):
         in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         ignore_ws = (
             "--ignore-whitespace"
-            if savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
+            if self.savvy_settings.get("inline_diff_ignore_eol_whitespaces", True)
             else None
         )
         selections = self.view.sel()

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -25,8 +25,7 @@ class LogMixin(object):
         sublime.set_timeout_async(lambda: self.run_async(file_path=file_path, **kwargs), 0)
 
     def run_async(self, file_path=None, **kwargs):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        follow = savvy_settings.get("log_follow_rename") if file_path else False
+        follow = self.savvy_settings.get("log_follow_rename") if file_path else False
         show_log_panel(
             self.log_generator(file_path=file_path, follow=follow, **kwargs),
             lambda commit: self.on_done(commit, file_path=file_path, **kwargs)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -43,9 +43,8 @@ class LogGraphMixin(object):
         view.run_command("gs_log_graph_navigate")
 
     def get_graph_args(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        args = savvy_settings.get("git_graph_args")
-        follow = savvy_settings.get("log_follow_rename")
+        args = self.savvy_settings.get("git_graph_args")
+        follow = self.savvy_settings.get("log_follow_rename")
         if self._file_path and follow:
             args = args + ["--follow"]
         if self._file_path:
@@ -231,8 +230,7 @@ class GsLogGraphMoreInfoCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        show_more = savvy_settings.get("graph_show_more_commit_info")
+        show_more = self.savvy_settings.get("graph_show_more_commit_info")
         if not show_more:
             return
 
@@ -261,9 +259,8 @@ class GsLogGraphToggleMoreInfoCommand(TextCommand, WindowCommand, GitCommand):
     """
 
     def run(self, edit):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        show_more = not savvy_settings.get("graph_show_more_commit_info")
-        savvy_settings.set("graph_show_more_commit_info", show_more)
+        show_more = not self.savvy_settings.get("graph_show_more_commit_info")
+        self.savvy_settings.set("graph_show_more_commit_info", show_more)
         if not show_more:
             self.view.window().run_command("hide_panel")
 

--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -25,11 +25,10 @@ class GsMergeCommand(WindowCommand, GitCommand):
     def on_branch_selection(self, branch):
         if not branch:
             return
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         try:
             self.git(
                 "merge",
-                "--log" if savvy_settings.get("merge_log") else None,
+                "--log" if self.savvy_settings.get("merge_log") else None,
                 branch
             )
         finally:

--- a/core/commands/push.py
+++ b/core/commands/push.py
@@ -22,8 +22,7 @@ class PushBase(GitCommand):
         """
         Perform `git push remote branch`.
         """
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        if force and savvy_settings.get("confirm_force_push"):
+        if force and self.savvy_settings.get("confirm_force_push"):
             if not sublime.ok_cancel_dialog(CONFIRM_FORCE_PUSH):
                 return
 
@@ -51,7 +50,6 @@ class GsPushCommand(WindowCommand, PushBase):
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         if self.local_branch_name:
             upstream = self.get_local_branch(self.local_branch_name).tracking
         else:
@@ -62,7 +60,7 @@ class GsPushCommand(WindowCommand, PushBase):
             remote, remote_branch = upstream.split("/", 1)
             self.do_push(
                 remote, self.local_branch_name, remote_branch=remote_branch, force=self.force)
-        elif savvy_settings.get("prompt_for_tracking_branch"):
+        elif self.savvy_settings.get("prompt_for_tracking_branch"):
             if sublime.ok_cancel_dialog(SET_UPSTREAM_PROMPT):
                 self.window.run_command("gs_push_to_branch_name", {
                     "set_upstream": True,

--- a/core/commands/reset.py
+++ b/core/commands/reset.py
@@ -28,7 +28,7 @@ class ResetMixin(object):
             return
         self._selected_hash = commit_hash
 
-        use_reset_mode = sublime.load_settings("GitSavvy.sublime-settings").get("use_reset_mode")
+        use_reset_mode = self.savvy_settings.get("use_reset_mode")
         if use_reset_mode:
             self.on_reset(use_reset_mode)
         else:

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -15,7 +15,6 @@ class GsShowCommitCommand(WindowCommand, GitCommand):
     def run(self, commit_hash):
         # need to get repo_path before the new view is created.
         repo_path = self.repo_path
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         view = self.window.new_file()
         settings = view.settings()
         settings.set("git_savvy.show_commit_view", True)
@@ -23,7 +22,7 @@ class GsShowCommitCommand(WindowCommand, GitCommand):
         settings.set("git_savvy.repo_path", repo_path)
         settings.set("git_savvy.show_commit_view.ignore_whitespace", False)
         settings.set("git_savvy.show_commit_view.show_word_diff", False)
-        settings.set("git_savvy.show_commit_view.show_diffstat", savvy_settings.get("show_diffstat", True))
+        settings.set("git_savvy.show_commit_view.show_diffstat", self.savvy_settings.get("show_diffstat", True))
         view.set_syntax_file("Packages/GitSavvy/syntax/show_commit.sublime-syntax")
         view.set_name(SHOW_COMMIT_TITLE.format(self.get_short_hash(commit_hash)))
         view.set_scratch(True)

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -10,9 +10,8 @@ class GsShowCommitInfoCommand(WindowCommand, GitCommand):
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        show_full = savvy_settings.get("show_full_commit_info")
-        show_diffstat = savvy_settings.get("show_diffstat")
+        show_full = self.savvy_settings.get("show_full_commit_info")
+        show_diffstat = self.savvy_settings.get("show_diffstat")
         text = self.git(
             "show",
             "--no-color",

--- a/core/commands/status_bar.py
+++ b/core/commands/status_bar.py
@@ -45,7 +45,7 @@ class GsUpdateStatusBarCommand(TextCommand, GitCommand):
             return
 
         global last_execution, update_status_bar_soon
-        if sublime.load_settings("GitSavvy.sublime-settings").get("git_status_in_status_bar"):
+        if self.savvy_settings.get("git_status_in_status_bar"):
 
             millisec = int(round(time.time() * 1000))
             # If we updated to less then 100 ms we don't need to update now but

--- a/core/commands/tag.py
+++ b/core/commands/tag.py
@@ -107,10 +107,9 @@ class GsTagCreateCommand(TextCommand, GitCommand):
             return util.log.panel("\"{}\" is not a valid tag name.".format(tag_name))
 
         self.tag_name = stdout.strip()[10:]
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         self.window.show_input_panel(
             TAG_CREATE_MESSAGE_PROMPT,
-            savvy_settings.get("default_tag_message").format(tag_name=tag_name),
+            self.savvy_settings.get("default_tag_message").format(tag_name=tag_name),
             self.on_entered_message,
             None,
             None

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -28,6 +28,7 @@ from .git_mixins.history import HistoryMixin
 from .git_mixins.rewrite import RewriteMixin
 from .git_mixins.merge import MergeMixin
 from .exceptions import GitSavvyError
+from .settings import SettingsMixin
 import time
 
 git_path = None
@@ -58,7 +59,8 @@ class LoggingProcessWrapper(object):
     """
     Wraps a Popen object with support for logging stdin/stderr
     """
-    def __init__(self, process):
+    def __init__(self, process, timeout):
+        self.timeout = timeout
         self.process = process
         self.stdout = b''
         self.stderr = b''
@@ -98,11 +100,8 @@ class LoggingProcessWrapper(object):
 
         self.process.wait()
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        timeout = savvy_settings.get("live_panel_output_timeout", 10000)
-
-        stdout_thread.join(timeout / 1000)
-        stderr_thread.join(timeout / 1000)
+        stdout_thread.join(self.timeout / 1000)
+        stderr_thread.join(self.timeout / 1000)
 
         return self.stdout, self.stderr
 
@@ -118,7 +117,8 @@ class GitCommand(StatusMixin,
                  TagsMixin,
                  HistoryMixin,
                  RewriteMixin,
-                 MergeMixin
+                 MergeMixin,
+                 SettingsMixin
                  ):
 
     """
@@ -149,16 +149,14 @@ class GitCommand(StatusMixin,
         command = (self.git_binary_path, ) + tuple(arg for arg in args if arg)
         command_str = " ".join(command)
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-
-        show_panel_overrides = savvy_settings.get("show_panel_for")
+        show_panel_overrides = self.savvy_settings.get("show_panel_for")
         show_panel = show_panel or args[0] in show_panel_overrides
 
-        close_panel_for = savvy_settings.get("close_panel_for") or []
+        close_panel_for = self.savvy_settings.get("close_panel_for") or []
         if args[0] in close_panel_for:
             sublime.active_window().run_command("hide_panel", {"cancel": True})
 
-        live_panel_output = savvy_settings.get("live_panel_output", False)
+        live_panel_output = self.savvy_settings.get("live_panel_output", False)
 
         stdout, stderr = None, None
 
@@ -195,13 +193,13 @@ class GitCommand(StatusMixin,
             def initialize_panel():
                 # clear panel
                 util.log.panel("")
-                if savvy_settings.get("show_stdin_in_output") and stdin is not None:
+                if self.savvy_settings.get("show_stdin_in_output") and stdin is not None:
                     util.log.panel_append("STDIN\n{}\n".format(stdin))
-                if savvy_settings.get("show_input_in_output"):
+                if self.savvy_settings.get("show_input_in_output"):
                     util.log.panel_append("> {}\n".format(command_str))
 
             if show_panel and live_panel_output:
-                wrapper = LoggingProcessWrapper(p)
+                wrapper = LoggingProcessWrapper(p, self.savvy_settings.get("live_panel_output_timeout", 10000))
                 initialize_panel()
 
             if stdin is not None and encode:
@@ -213,7 +211,7 @@ class GitCommand(StatusMixin,
                 stdout, stderr = p.communicate(stdin)
 
             if decode:
-                stdout, stderr = self.decode_stdout(stdout, savvy_settings), stderr.decode()
+                stdout, stderr = self.decode_stdout(stdout), stderr.decode()
 
             if show_panel and not live_panel_output:
                 initialize_panel()
@@ -236,12 +234,12 @@ class GitCommand(StatusMixin,
                 util.debug.log_git(
                     args,
                     stdin,
-                    self.decode_stdout(stdout, savvy_settings),
+                    self.decode_stdout(stdout),
                     stderr.decode(),
                     end - start
                 )
 
-            if show_panel and savvy_settings.get("show_time_elapsed_in_output", True):
+            if show_panel and self.savvy_settings.get("show_time_elapsed_in_output", True):
                 util.log.panel_append("\n[Done in {:.2f}s]".format(end - start))
 
         if throw_on_stderr and not p.returncode == 0:
@@ -262,9 +260,9 @@ class GitCommand(StatusMixin,
 
         return stdout
 
-    def decode_stdout(self, stdout, savvy_settings):
-        fallback_encoding = savvy_settings.get("fallback_encoding")
-        silent_fallback = savvy_settings.get("silent_fallback")
+    def decode_stdout(self, stdout):
+        fallback_encoding = self.savvy_settings.get("fallback_encoding")
+        silent_fallback = self.savvy_settings.get("silent_fallback")
         try:
             return stdout.decode()
         except UnicodeDecodeError as unicode_err:
@@ -291,7 +289,7 @@ class GitCommand(StatusMixin,
 
         global git_path, error_message_displayed
         if not git_path:
-            git_path_setting = sublime.load_settings("GitSavvy.sublime-settings").get("git_path")
+            git_path_setting = self.savvy_settings.get("git_path")
             if isinstance(git_path_setting, dict):
                 git_path = git_path_setting.get(sublime.platform())
                 if not git_path:
@@ -330,7 +328,7 @@ class GitCommand(StatusMixin,
         if not git_path:
             msg = ("Your Git binary cannot be found.  If it is installed, add it "
                    "to your PATH environment variable, or add a `git_path` setting "
-                   "in the `User/GitSavvy.sublime-settings` file.")
+                   "in the GitSavvy settings.")
             if not error_message_displayed:
                 sublime.error_message(msg)
                 error_message_displayed = True
@@ -462,8 +460,7 @@ class GitCommand(StatusMixin,
         """
         git_cmd, *addl_args = args
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        global_flags = savvy_settings.get("global_flags")
+        global_flags = self.savvy_settings.get("global_flags")
 
         if global_flags and git_cmd in global_flags:
             args = [git_cmd] + global_flags[git_cmd] + addl_args

--- a/core/git_mixins/branches.py
+++ b/core/git_mixins/branches.py
@@ -48,8 +48,7 @@ class BranchesMixin():
             # remove brackets
             tracking_status = tracking_status[1:len(tracking_status) - 1]
 
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        enable_branch_descriptions = savvy_settings.get("enable_branch_descriptions")
+        enable_branch_descriptions = self.savvy_settings.get("enable_branch_descriptions")
 
         hide_description = is_remote or not enable_branch_descriptions
         description = "" if hide_description else self.git(

--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -40,8 +40,7 @@ class GsTabCycleCommand(TextCommand, GitCommand):
             sublime.set_timeout_async(self.view.close)
 
     def get_next(self, source, reverse=False):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        tab_order = savvy_settings.get("tab_order")
+        tab_order = self.savvy_settings.get("tab_order")
 
         if reverse is True:
             tab_order.reverse()

--- a/core/interfaces/branch.py
+++ b/core/interfaces/branch.py
@@ -80,8 +80,7 @@ class BranchInterface(ui.Interface, GitCommand):
         return "BRANCHES: {}".format(os.path.basename(self.repo_path))
 
     def pre_render(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        sort_by_recent = savvy_settings.get("sort_by_recent_in_branch_dashboard")
+        sort_by_recent = self.savvy_settings.get("sort_by_recent_in_branch_dashboard")
         self._branches = tuple(self.get_branches(sort_by_recent))
 
     def on_new_dashboard(self):
@@ -123,8 +122,7 @@ class BranchInterface(ui.Interface, GitCommand):
     @ui.partial("remotes")
     def render_remotes(self):
         if self.show_remotes is None:
-            savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-            self.show_remotes = savvy_settings.get("show_remotes_in_branch_dashboard")
+            self.show_remotes = self.savvy_settings.get("show_remotes_in_branch_dashboard")
 
         return (self.render_remotes_on()
                 if self.show_remotes else

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -227,8 +227,7 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
                 skip_commit_key='k' if not vintageous_friendly else 'K')
 
     def preserve_merges(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        default = savvy_settings.get("rebase_preserve_merges")
+        default = self.savvy_settings.get("rebase_preserve_merges")
         return not self.in_rebase_apply() and \
             (self.in_rebase_merge() or
              self.view.settings().get("git_savvy.rebase.preserve_merges", default))
@@ -1054,8 +1053,7 @@ class GsRebaseTogglePreserveModeCommand(TextCommand, GitCommand):
     def run(self, edit):
         preserve = self.view.settings().get("git_savvy.rebase.preserve_merges", False)
         self.view.settings().set("git_savvy.rebase.preserve_merges", not preserve)
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        savvy_settings.set("rebase_preserve_merges", not preserve)
+        self.savvy_settings.set("rebase_preserve_merges", not preserve)
         util.view.refresh_gitsavvy(self.view)
 
 

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -79,9 +79,8 @@ class TagsInterface(ui.Interface, GitCommand):
 
     def pre_render(self):
         if self.show_remotes is None:
-            savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-            self.show_remotes = savvy_settings.get("show_remotes_in_tags_dashboard")
-            self.max_items = savvy_settings.get("max_items_in_tags_dashboard", None)
+            self.show_remotes = self.savvy_settings.get("show_remotes_in_tags_dashboard")
+            self.max_items = self.savvy_settings.get("max_items_in_tags_dashboard", None)
 
         self.local_tags = self.get_tags(reverse=True)
         if not self.remotes and self.show_remotes:

--- a/core/settings.py
+++ b/core/settings.py
@@ -8,8 +8,8 @@ class GitSavvySettings:
 
     def get(self, key, default=None):
         project_data = sublime.active_window().project_data()
-        if project_data and "settings" in project_data and "GitSavvy" in project_data["settings"]:
-            project_savvy_settings = project_data["settings"]["GitSavvy"]
+        if project_data and "GitSavvy" in project_data:
+            project_savvy_settings = project_data["GitSavvy"]
             if key in project_savvy_settings:
                 return project_savvy_settings.get(key)
         return self.global_settings.get(key, default)

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,0 +1,23 @@
+import sublime
+
+
+class GitSavvySettings:
+    def __init__(self, parent=None):
+        self.parent = parent
+        self.global_settings = sublime.load_settings("GitSavvy.sublime-settings")
+
+    def get(self, key, default=None):
+        return self.global_settings.get(key, default)
+
+    def set(self, key, value):
+        self.global_settings.set(key, value)
+
+
+class SettingsMixin:
+    _savvy_settings = None
+
+    @property
+    def savvy_settings(self):
+        if not self._savvy_settings:
+            self._savvy_settings = GitSavvySettings(self)
+        return self._savvy_settings

--- a/core/settings.py
+++ b/core/settings.py
@@ -7,6 +7,11 @@ class GitSavvySettings:
         self.global_settings = sublime.load_settings("GitSavvy.sublime-settings")
 
     def get(self, key, default=None):
+        project_data = sublime.active_window().project_data()
+        if project_data and "settings" in project_data and "GitSavvy" in project_data["settings"]:
+            project_savvy_settings = project_data["settings"]["GitSavvy"]
+            if key in project_savvy_settings:
+                return project_savvy_settings.get(key)
         return self.global_settings.get(key, default)
 
     def set(self, key, value):

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -2,6 +2,7 @@ import itertools
 import sublime
 from ...common import util
 from ..git_command import GitCommand
+from ..settings import GitSavvySettings
 
 
 class PanelActionMixin(object):
@@ -514,8 +515,7 @@ class LogPanel(PaginatedPanel):
     def on_highlight_async(self, commit):
         if not commit:
             return
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-        show_more = savvy_settings.get("log_show_more_commit_info")
+        show_more = GitSavvySettings().get("log_show_more_commit_info")
         if not show_more:
             return
         sublime.active_window().run_command(

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,12 +190,9 @@ To open the GitSavvy settings, simply run the `Preferences: GitSavvy Settings` c
 
 ```
 {
-    "settings":
+    "GitSavvy":
     {
-        "GitSavvy":
-        {
-            // GitSavvy settings go here
-        }
+        // GitSavvy settings go here
     }
 }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -185,7 +185,20 @@ For all syntax specific view we have a settings file. These are nothing extra fr
 
 ### Editing Settings
 
-To open the GitSavvy settings, simply run the `Preferences: GitSavvy Settings` command from the command palette. The default settings are documented with helpful inline comments.
+To open the GitSavvy settings, simply run the `Preferences: GitSavvy Settings` command from the command palette. The default settings are documented with helpful inline comments. GitSavvy also supports project specific settings, run the 
+`Preference: GitSavvy Project Settings` command and add the key `"GitSavvy"` as follows
+
+```
+{
+    "settings":
+    {
+        "GitSavvy":
+        {
+            // GitSavvy settings go here
+        }
+    }
+}
+```
 
 [Preferences Editor](https://packagecontrol.io/packages/Preferences%20Editor) is really good package for editing you settings.
 

--- a/docs/branch_mgmt.md
+++ b/docs/branch_mgmt.md
@@ -90,7 +90,7 @@ A scratch view will be opened, showing the commit diff between the selected bran
 
 By default, remote branches are not displayed in the branch dashboard.  In many cases, there are many remote branches that would overwhelm the interface.  To view, press `e`.  To hide, press `e` again.
 
-If you would like the default behavior to be inverted, set `show_remotes_in_branch_dashboard` in `GitSavvy.sublime-settings`.
+If you would like the default behavior to be inverted, set `show_remotes_in_branch_dashboard` in `GitSavvy` settings.
 
 #### Edit branch description (`E`)
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -7,7 +7,7 @@ If you're doing development on GitSavvy, the following commands may be useful.
 
 This command will reload all GitSavvy-related Python modules and initiate a plugin reset for Sublime Text 3.  Note that the editor's interface may become unresponsive for a second or two while the plugins are reloaded.  However, this workflow is often preferable to closing and re-opening Sublime when testing changes to GitSavvy.
 
-This command will only have an effect if `dev_mode` is set to `true` in `Packages/User/GitSavvy.sublime-settings`.
+This command will only have an effect if `dev_mode` is set to `true` in `GitSavvy` settings.
 
 
 ## `GitSavvy: enable logging`

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -1,6 +1,6 @@
 # git-flow
 
-Vincent Driessen's [git-flow](https://github.com/nvie/gitflow) extension is fully supported, allowing you to run flow commands with sublime commands. To enable `git-flow` integration you must set `show_git_flow_commands` to `true` in `Packages/User/GitSavvy.sublime-settings`.
+Vincent Driessen's [git-flow](https://github.com/nvie/gitflow) extension is fully supported, allowing you to run flow commands with sublime commands. To enable `git-flow` integration you must set `show_git_flow_commands` to `true` in `GitSavvy` settings.
 
 Most commands attempt to mirror `git-flow` 's interface with the added ability to select a target from local branches/remotes.
 

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -14,7 +14,7 @@ This command will change the HEAD of the current branch to a previous commit.
 
 When run, you will be asked to select a commit from a list of previous commits. Once you select a commit, you will prompted for a reset mode. Once you select a reset mode the HEAD of the current branch will be changed to the selected commit, and your index and working directory will be updated depending on the reset mode you selected. For more information about reset modes, see the [git reset documentation](https://git-scm.com/docs/git-reset).
 
-To always use a specific reset mode, set `use_reset_mode` to a valid git reset mode flag (e.g. `--soft`, `--hard`) in `Packages/User/GitSavvy.sublime-settings`.
+To always use a specific reset mode, set `use_reset_mode` to a valid git reset mode flag (e.g. `--soft`, `--hard`) in `GitSavvy` settings.
 
 ## `git: reset to branch`
 

--- a/github/commands/add_fork_as_remote.py
+++ b/github/commands/add_fork_as_remote.py
@@ -19,7 +19,6 @@ class GsGithubAddForkAsRemoteCommand(WindowCommand, GitCommand, git_mixins.Githu
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         base_remote = github.parse_remote(self.get_integrated_remote_url())
         base_repo_data = github.get_repo_data(base_remote)
         parent = None
@@ -39,7 +38,7 @@ class GsGithubAddForkAsRemoteCommand(WindowCommand, GitCommand, git_mixins.Githu
         show_paginated_panel(
             forks,
             self.on_select_fork,
-            limit=savvy_settings.get("github_per_page_max", 100),
+            limit=self.savvy_settings.get("github_per_page_max", 100),
             format_item=lambda fork: (fork["full_name"], fork),
             status_message="Getting forks...")
 

--- a/github/commands/commit.py
+++ b/github/commands/commit.py
@@ -39,7 +39,6 @@ class GsGithubShowIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemote
         sublime.set_timeout_async(lambda: self.run_async(nondefault_repo))
 
     def run_async(self, nondefault_repo):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         remote = github.parse_remote(self.get_integrated_remote_url())
 
         if nondefault_repo:
@@ -57,7 +56,7 @@ class GsGithubShowIssuesCommand(TextCommand, GitCommand, git_mixins.GithubRemote
             issues,
             self.on_done,
             format_item=self.format_item,
-            limit=savvy_settings.get("github_per_page_max", 100),
+            limit=self.savvy_settings.get("github_per_page_max", 100),
             status_message="Getting issues..."
         )
         if pp.is_empty():
@@ -97,7 +96,6 @@ class GsGithubShowContributorsCommand(TextCommand, GitCommand):
         sublime.set_timeout_async(lambda: self.run_async())
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         default_remote_name, default_remote = self.get_remotes().popitem(last=False)
         remote = github.parse_remote(default_remote)
 
@@ -107,7 +105,7 @@ class GsGithubShowContributorsCommand(TextCommand, GitCommand):
             contributors,
             self.on_done,
             format_item=self.format_item,
-            limit=savvy_settings.get("github_per_page_max", 100),
+            limit=self.savvy_settings.get("github_per_page_max", 100),
             status_message="Getting contributors..."
         )
         if pp.is_empty():

--- a/github/commands/pull_request.py
+++ b/github/commands/pull_request.py
@@ -28,14 +28,13 @@ class GsGithubPullRequestCommand(WindowCommand, GitCommand, git_mixins.GithubRem
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         base_remote = github.parse_remote(self.get_integrated_remote_url())
         self.pull_requests = github.get_pull_requests(base_remote)
 
         pp = show_paginated_panel(
             self.pull_requests,
             self.on_select_pr,
-            limit=savvy_settings.get("github_per_page_max", 100),
+            limit=self.savvy_settings.get("github_per_page_max", 100),
             format_item=self.format_item,
             status_message="Getting pull requests..."
         )

--- a/github/github.py
+++ b/github/github.py
@@ -6,12 +6,11 @@ import re
 from collections import namedtuple
 from webbrowser import open as open_in_browser
 from functools import partial
-import urllib
-
-import sublime
 
 from ..common import interwebs, util
 from ..core.exceptions import FailedGithubRequest
+from ..core.settings import GitSavvySettings
+
 
 GITHUB_PER_PAGE_MAX = 100
 GITHUB_ERROR_TEMPLATE = "Error {action} Github: {payload}"
@@ -72,8 +71,7 @@ def parse_remote(remote):
 
     fqdn, owner, repo = match.groups()
 
-    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-    api_tokens = savvy_settings.get("api_tokens")
+    api_tokens = GitSavvySettings().get("api_tokens")
     token = api_tokens and api_tokens.get(fqdn, None) or None
 
     return GitHubRepo(url, fqdn, owner, repo, token)

--- a/gitlab/commands/merge_request.py
+++ b/gitlab/commands/merge_request.py
@@ -28,7 +28,6 @@ class GsGitlabMergeRequestCommand(WindowCommand, GitCommand, git_mixins.GitLabRe
         sublime.set_timeout_async(self.run_async, 0)
 
     def run_async(self):
-        savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
         self.remote_url = self.get_integrated_remote_url()
         self.base_remote = gitlab.parse_remote(self.remote_url)
         self.merge_requests = gitlab.get_merge_requests(self.base_remote)
@@ -36,7 +35,7 @@ class GsGitlabMergeRequestCommand(WindowCommand, GitCommand, git_mixins.GitLabRe
         pp = show_paginated_panel(
             self.merge_requests,
             self.on_select_mr,
-            limit=savvy_settings.get("gitlab_per_page_max", 100),
+            limit=self.savvy_settings.get("gitlab_per_page_max", 100),
             format_item=self.format_item,
             status_message="Getting merge requests..."
         )

--- a/gitlab/gitlab.py
+++ b/gitlab/gitlab.py
@@ -6,12 +6,11 @@ import re
 from collections import namedtuple
 from functools import partial, lru_cache
 from webbrowser import open as open_in_browser
-import urllib
-
-import sublime
 
 from ..common import interwebs, util
 from ..core.exceptions import FailedGitLabRequest
+from ..core.settings import GitSavvySettings
+
 
 GITLAB_PER_PAGE_MAX = 100
 GITLAB_ERROR_TEMPLATE = "Error {action} GitLab: {payload}"
@@ -74,8 +73,7 @@ def parse_remote(remote):
 
     fqdn, owner, repo = match.groups()
 
-    savvy_settings = sublime.load_settings("GitSavvy.sublime-settings")
-    api_tokens = savvy_settings.get("api_tokens")
+    api_tokens = GitSavvySettings().get("api_tokens")
     token = api_tokens and api_tokens.get(fqdn, None) or None
 
     return GitLabRepo(url, fqdn, owner, repo, token)


### PR DESCRIPTION
this adds support of project-wise settings by refactoring settings related code.

A [new command](https://github.com/divmain/GitSavvy/blob/10b0ef94844eb823930be697a6fda659479e3e67/docs/README.md#editing-settings) `Preference: GitSavvy Project Settings` is also added to allow easier editing.