### PR TITLE
Doc: update codacy badge address

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/divmain/GitSavvy.svg?branch=master)](https://travis-ci.org/divmain/GitSavvy)
 [![AppVeyor branch](https://img.shields.io/appveyor/ci/divmain/GitSavvy/master.svg)](https://ci.appveyor.com/project/divmain/GitSavvy)
 [![Coverage Status](https://coveralls.io/repos/github/divmain/GitSavvy/badge.svg)](https://coveralls.io/github/divmain/GitSavvy)
-[![Codacy Badge](https://www.codacy.com/project/badge/3c214fa790b249f79f5275dbfa6499ca)](https://www.codacy.com/app/dale/GitSavvy)
+[![Codacy Badge](https://api.codacy.com/project/badge/3c214fa790b249f79f5275dbfa6499ca)](https://www.codacy.com/app/dale/GitSavvy)
 ![License](https://camo.githubusercontent.com/890acbdcb87868b382af9a4b1fac507b9659d9bf/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d4d49542d626c75652e737667)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/divmain/GitSavvy?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
Update the codacy badge in README. Currently, it is a dead image.