### PR TITLE
Enhancement: make `rebase_default_base_ref` more consistent

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -292,6 +292,11 @@
 
 
     /*
+        The default base for the rebase dashboard.
+    */
+    "rebase_default_base_ref": "",
+
+    /*
         When set to `true`, rebase dashboard uses preserve-merges mode when opened.
     */
     "rebase_preserve_merges": false,

--- a/core/interfaces/rebase.py
+++ b/core/interfaces/rebase.py
@@ -319,9 +319,7 @@ class RebaseInterface(ui.Interface, NearestBranchMixin, GitCommand):
         base_ref = self.view.settings().get("git_savvy.rebase.base_ref")
 
         if not base_ref or reset_ref:
-            project_data = sublime.active_window().project_data() or {}
-            project_settings = project_data.get('settings', {})
-            base_ref = project_settings.get("rebase_default_base_ref")
+            base_ref = self.savvy_settings.get("rebase_default_base_ref")
 
             if not base_ref:
                 # use remote tracking branch as a sane default

--- a/docs/rebase.md
+++ b/docs/rebase.md
@@ -88,16 +88,11 @@ The resulting branch is then used as the starting point for the displayed inform
 
 #### Define base ref for the dashboard (`f`)
 
-If you want to compare the current branch against something other than the initially detected branch, using this command will allow you to make that selection. You can override the default, per-project, by adding a `rebase_default_base_ref` to your `.sublime-project` file:
+If you want to compare the current branch against something other than the initially detected branch, using this command will allow you to make that selection. You can override the default, per-project, by running `Preference: GitSavvy Project Settings`:
 
 ```json
 {
-    "folders": [
-        {
-           "path": "XYZ"
-        }
-    ],
-    "settings": {
+    "GitSavvy": {
         "rebase_default_base_ref": "develop"
     }
 }


### PR DESCRIPTION
This PR makes `rebase_default_base_ref` more consistent with project-wise settings.  Originally, `rebase_default_base_ref` was put under the key `settings` which is not consistent with the project-wise settings.