### PR TITLE
Some refactoring of the blame view and LogPanel

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -273,6 +273,13 @@
     "blame_follow_rename": false,
 
     /*
+        Set it to "file", "commit" or "all_commits" to specify the default detection
+        method for the blame view.
+    */
+
+    "blame_detect_move_or_copy_within": "file",
+
+    /*
         When set to `true`, GitSavvy will prompt for confirmation when closing
         the commit message view.
     */

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -21,6 +21,8 @@ class LogMixin(object):
     but the subclass must also inherit fro GitCommand (for the `git()` method)
     """
 
+    selected_index = 0
+
     def run(self, *args, file_path=None, **kwargs):
         sublime.set_timeout_async(lambda: self.run_async(file_path=file_path, **kwargs), 0)
 
@@ -28,7 +30,8 @@ class LogMixin(object):
         follow = self.savvy_settings.get("log_follow_rename") if file_path else False
         show_log_panel(
             self.log_generator(file_path=file_path, follow=follow, **kwargs),
-            lambda commit: self.on_done(commit, file_path=file_path, **kwargs)
+            lambda commit: self.on_done(commit, file_path=file_path, **kwargs),
+            selected_index=self.selected_index
         )
 
     def on_done(self, commit, **kwargs):

--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -21,6 +21,7 @@ class LogMixin(object):
     but the subclass must also inherit fro GitCommand (for the `git()` method)
     """
 
+    show_commit_info = True
     selected_index = 0
 
     def run(self, *args, file_path=None, **kwargs):
@@ -31,8 +32,13 @@ class LogMixin(object):
         show_log_panel(
             self.log_generator(file_path=file_path, follow=follow, **kwargs),
             lambda commit: self.on_done(commit, file_path=file_path, **kwargs),
-            selected_index=self.selected_index
+            selected_index=self.selected_index,
+            on_highlight=self.on_highlight,
+            show_commit_info=self.show_commit_info
         )
+
+    def on_highlight(self, commit):
+        pass
 
     def on_done(self, commit, **kwargs):
         if commit:

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -488,7 +488,7 @@ def show_log_panel(entries, on_done, **kwargs):
 
     """
     _kwargs = {}
-    for option in ['selected_index', 'on_highlight', 'limit']:
+    for option in ['selected_index', 'on_highlight', 'limit', 'show_commit_info']:
         if option in kwargs:
             _kwargs[option] = kwargs[option]
 
@@ -498,6 +498,8 @@ def show_log_panel(entries, on_done, **kwargs):
 
 
 class LogPanel(PaginatedPanel):
+
+    show_commit_info = True
 
     def format_item(self, entry):
         return ([entry.short_hash + " " + entry.summary,
@@ -509,17 +511,21 @@ class LogPanel(PaginatedPanel):
         return [">>> NEXT {} COMMITS >>>".format(self.limit),
                 "Skip this set of commits and choose from the next-oldest batch."]
 
-    def on_highlight(self, commit):
-        sublime.set_timeout_async(lambda: self.on_highlight_async(commit))
+    def _on_highlight(self, index):
+        super()._on_highlight(index)
+        if self.show_commit_info:
+            sublime.set_timeout_async(lambda: self.default_on_highlight(index))
 
-    def on_highlight_async(self, commit):
-        if not commit:
+    def default_on_highlight(self, index):
+        if self._empty_message_shown:
             return
-        show_more = GitSavvySettings().get("log_show_more_commit_info")
-        if not show_more:
+        if index == self.limit or index == -1:
             return
         sublime.active_window().run_command(
-            "gs_show_commit_info", {"commit_hash": commit})
+            "gs_show_commit_info", {"commit_hash": self.ret_list[index]})
+
+    def on_highlight(self, commit):
+        pass
 
     def on_selection(self, commit):
         self.commit = commit


### PR DESCRIPTION
1. added an option `blame_detect_move_or_copy_within` in settings

2. match line with picking another commit to blame, instead of showing the new blame in the current view, I find that it is more useful to open a new view of the select committee.

3. refactored `LogPanel` to make some of the options more configurable.