### PR TITLE
Enhancement: get remote url from api call

### DIFF
--- a/github/commands/create_fork.py
+++ b/github/commands/create_fork.py
@@ -26,17 +26,21 @@ class GsGithubCreateForkCommand(PanelCommandMixin, WindowCommand, GitCommand,
         base_remote = github.parse_remote(self.get_integrated_remote_url())
         self.window.status_message(START_CREATE_MESSAGE.format(repo=base_remote))
         result = github.create_fork(base_remote)
+        self.clone_url = result["clone_url"] if "clone_url" in result else None
+        self.ssh_url = result["ssh_url"] if "ssh_url" in result else None
         self.window.status_message(END_CREATE_MESSAGE)
         util.debug.add_to_log(("github: fork result:\n{}".format(result)))
         self.window.show_quick_panel(
-            ["Fork created, do you want to add it as remote?",
-             "Yes",
-             "No"],
+            ["Add fork as remote?",
+             self.clone_url,
+             self.ssh_url],
             self.on_select_action
         )
 
     def on_select_action(self, idx):
-        if idx != 1:
+        if idx == 0:
             return
-
-        self.window.run_command("gs_add_fork_as_remote",)
+        elif idx == 1:
+            self.window.run_command("gs_remote_add", {"url": self.clone_url})
+        elif idx == 2:
+            self.window.run_command("gs_remote_add", {"url": self.ssh_url})


### PR DESCRIPTION
Make it easier to add fork as remote by using the URLs returned by the api call.