### PR TITLE
Fix subprocess command crashing with OSError

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -307,7 +307,10 @@ class GitCommand(StatusMixin,
                     startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
                 stdout = subprocess.check_output(
-                    [git_path, "--version"], startupinfo=startupinfo).decode("utf-8")
+                    [git_path, "--version"],
+                    stderr=subprocess.PIPE,
+                    startupinfo=startupinfo).decode("utf-8")
+
             except Exception:
                 stdout = ""
                 git_path = None


### PR DESCRIPTION
subprocess.check_output crashes with message:
OSError: [WinError 6] The handle is invalid
The issue seems to be with stderr

I'm not very familiar with python or subprocess, I only tested a couple of things and this seems to work.