### PR TITLE
Fix: forward stderr to stdout

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -307,7 +307,7 @@ class GitCommand(StatusMixin,
                     startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
                 stdout = subprocess.check_output(
-                    [git_path, "--version"], startupinfo=startupinfo).decode("utf-8")
+                    [git_path, "--version"], stderr=subprocess.STDOUT, startupinfo=startupinfo).decode("utf-8")
             except Exception:
                 stdout = ""
                 git_path = None


### PR DESCRIPTION
`git --version` prints to stderr on windows
