### PR TITLE
Internal: Refactor away show_commit_info from LogPanel

### DIFF
--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -21,7 +21,6 @@ class LogMixin(object):
     but the subclass must also inherit fro GitCommand (for the `git()` method)
     """
 
-    show_commit_info = True
     selected_index = 0
 
     def run(self, *args, file_path=None, **kwargs):
@@ -32,13 +31,8 @@ class LogMixin(object):
         show_log_panel(
             self.log_generator(file_path=file_path, follow=follow, **kwargs),
             lambda commit: self.on_done(commit, file_path=file_path, **kwargs),
-            selected_index=self.selected_index,
-            on_highlight=self.on_highlight,
-            show_commit_info=self.show_commit_info
+            selected_index=self.selected_index
         )
-
-    def on_highlight(self, commit):
-        pass
 
     def on_done(self, commit, **kwargs):
         if commit:

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -488,7 +488,7 @@ def show_log_panel(entries, on_done, **kwargs):
 
     """
     _kwargs = {}
-    for option in ['selected_index', 'on_highlight', 'limit', 'show_commit_info']:
+    for option in ['selected_index', 'on_highlight', 'limit']:
         if option in kwargs:
             _kwargs[option] = kwargs[option]
 
@@ -498,8 +498,6 @@ def show_log_panel(entries, on_done, **kwargs):
 
 
 class LogPanel(PaginatedPanel):
-
-    show_commit_info = True
 
     def format_item(self, entry):
         return ([entry.short_hash + " " + entry.summary,
@@ -511,21 +509,9 @@ class LogPanel(PaginatedPanel):
         return [">>> NEXT {} COMMITS >>>".format(self.limit),
                 "Skip this set of commits and choose from the next-oldest batch."]
 
-    def _on_highlight(self, index):
-        super()._on_highlight(index)
-        if self.show_commit_info:
-            sublime.set_timeout_async(lambda: self.default_on_highlight(index))
-
-    def default_on_highlight(self, index):
-        if self._empty_message_shown:
-            return
-        if index == self.limit or index == -1:
-            return
-        sublime.active_window().run_command(
-            "gs_show_commit_info", {"commit_hash": self.ret_list[index]})
-
     def on_highlight(self, commit):
-        pass
+        sublime.active_window().run_command(
+            "gs_show_commit_info", {"commit_hash": commit})
 
     def on_selection(self, commit):
         self.commit = commit

--- a/core/ui_mixins/quick_panel.py
+++ b/core/ui_mixins/quick_panel.py
@@ -488,9 +488,14 @@ def show_log_panel(entries, on_done, **kwargs):
 
     """
     _kwargs = {}
-    for option in ['selected_index', 'on_highlight', 'limit']:
+    for option in ['selected_index', 'limit']:
         if option in kwargs:
             _kwargs[option] = kwargs[option]
+
+    if 'on_highlight' in kwargs:
+        _kwargs['on_highlight'] = kwargs['on_highlight']
+        if not callable(kwargs['on_highlight']):
+            _kwargs['on_highlight'] = lambda commit: None
 
     lp = LogPanel(entries, on_done, **_kwargs)
     lp.show()


### PR DESCRIPTION
It is a lot more convenient to just set on_highlight.

When you need a different on_highligh you just overwrite the current one. Either
by a new call or as a kwargs to show_log_panel

For #956 to go easier