### PR TITLE
Allow using ~/%HOME% when providing clone path, by expanding user home dir

### DIFF
--- a/core/commands/init.py
+++ b/core/commands/init.py
@@ -108,7 +108,7 @@ class GsClone(WindowCommand, GitCommand):
         return ""
 
     def on_enter_directory(self, path):
-        self.suggested_git_root = path
+        self.suggested_git_root = os.path.expanduser(path)  # handle ~/%HOME%
         if self.suggested_git_root and os.path.exists(os.path.join(self.suggested_git_root, ".git")):
             sublime.ok_cancel_dialog(RECLONE_CANT_BE_DONE)
             return


### PR DESCRIPTION
I personally find this more useful than typing the path every time