### PR TITLE
Git log current file will highlight commit diff for current file

### DIFF
--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -32,7 +32,7 @@ class LogMixin(object):
             self.log_generator(file_path=file_path, follow=follow, **kwargs),
             lambda commit: self.on_done(commit, file_path=file_path, **kwargs),
             selected_index=self.selected_index,
-            on_highlight=self.on_highlight
+            on_highlight=lambda commit: self.on_highlight(commit, file_path=file_path)
         )
 
     def on_done(self, commit, **kwargs):
@@ -40,7 +40,7 @@ class LogMixin(object):
         if commit:
             self.do_action(commit, **kwargs)
 
-    def on_highlight(self, commit):
+    def on_highlight(self, commit, file_path=None):
         if not commit:
             return
         if not self.savvy_settings.get("log_show_more_commit_info", True):
@@ -50,7 +50,7 @@ class LogMixin(object):
         else:
             window = self.view.window()
         window.run_command(
-            "gs_show_commit_info", {"commit_hash": commit})
+            "gs_show_commit_info", {"commit_hash": commit, "file_path": file_path})
 
     def do_action(self, commit_hash, **kwargs):
         if hasattr(self, 'window'):

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -5,8 +5,9 @@ from ..git_command import GitCommand
 
 
 class GsShowCommitInfoCommand(WindowCommand, GitCommand):
-    def run(self, commit_hash):
+    def run(self, commit_hash, file_path=None):
         self._commit_hash = commit_hash
+        self._file_path = file_path
         sublime.set_timeout_async(self.run_async)
 
     def run_async(self):
@@ -18,7 +19,9 @@ class GsShowCommitInfoCommand(WindowCommand, GitCommand):
             "--format=fuller",
             "--stat" if show_diffstat else None,
             "--patch" if show_full else None,
-            self._commit_hash
+            self._commit_hash,
+            "--" if self._file_path else None,
+            self._file_path if self._file_path else None
         )
         output_view = self.window.create_output_panel("show_commit_info")
         output_view.set_read_only(False)


### PR DESCRIPTION
When runing git log current file is executed the highlight of the commit with only show the diff for the current file.