### PR TITLE
Make the debug log link absolute

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,4 +8,4 @@ Please include the following information when filing a bug:
 - Console error output
 - A description of the problem.
 - Steps to reproduce, if possible
-- If the bug is caused by a failing command, [include a debug log](docs/debug.md#providing-a-debug-log).
+- If the bug is caused by a failing command, [include a debug log](https://github.com/divmain/GitSavvy/blob/master/docs/debug.md#providing-a-debug-log).


### PR DESCRIPTION
To help users reach the guide faster when opening a bug report

Hotfixes should be submitted to `master` branch. As part of the PR process,
you will be asked to provide the information necessary to make that happen.

Pull requests on new features should be submitted to `dev` branch and will be
regularly merged into `master` after evaluations over an extended period of
time.
