### PR TITLE
Enhancement: better formating the initial text

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -155,7 +155,7 @@ class GsCommitInitializeViewCommand(TextCommand, GitCommand):
 
         if has_prepare_commit_msg_hook and os.path.exists(commit_editmsg_path):
             with util.file.safe_open(commit_editmsg_path, "r") as f:
-                initial_text = f.read() + help_text
+                initial_text = "\n" + f.read().rstrip() + help_text
         elif option_amend:
             last_commit_message = self.git("log", "-1", "--pretty=%B").strip()
             initial_text = last_commit_message + help_text


### PR DESCRIPTION
Make `COMMIT_EDITMSG` formatting a little bit better by adding a newline before it and remove the trailing newlines.