### PR TITLE
Enhancement: Add more complex git output scopes to diff syntax

### DIFF
--- a/syntax/diff.sublime-syntax
+++ b/syntax/diff.sublime-syntax
@@ -16,17 +16,60 @@ first_line_match: |-
       )
 contexts:
   main:
-    - match: ^diff.+$
-      scope: punctuation.definition.command.diff
+    # diff --git a/path/file.ext b/path/file.ext
+    - match: ^(diff)\s+(--git)\s+(a/.+?)\s+(b/.+?)$\n?
+      scope: meta.diff.header.git-output.command
+      captures:
+        1: keyword.other.command.diff
+        3: string.unquoted.from-file.diff
+        4: string.unquoted.to-file.diff
 
-    - match: ^index.+$
-      scope: punctuation.definition.index.diff
+    # index 00000000..1861c677
+    # index 1861c677..00000000
+    # index 3de5387c..a8dab191 100644
+    - match: ^(index)\s+(.+)(\.\.)(.+?)(?:\s+(\d+))?$\n?
+      scope: meta.diff.header.git-output.index
+      captures:
+        1: keyword.other.index.diff
+        2: constant.numeric.hex.from-commit.diff
+        3: punctuation.separator.sequence.diff
+        4: constant.numeric.hex.to-commit.diff
+        5: constant.numeric.integer.file-mode.diff
 
-    - match: ^new file mode.+$
-      scope: punctuation.definition.new-file-mode.diff
+    # similarity index 57%
+    - match: ^(similarity index)\s+(.+)$\n?
+      scope: meta.diff.header.git-output.similarity-index
+      captures:
+        1: keyword.other.similarity-index.diff
+        2: constant.numeric.integer.similarity-index.diff
 
-    - match: ^deleted file mode.+$
-      scope: punctuation.definition.deleted-file-mode.diff
+    # rename from path/file.ext
+    - match: ^(rename from)\s+(.+)$\n?
+      scope: meta.diff.header.git-output.rename-from
+      captures:
+        1: keyword.other.rename-from.diff
+        2: string.unquoted.from-file.diff
+
+    # rename to path/file.ext
+    - match: ^(rename to)\s+(.+)$\n?
+      scope: meta.diff.header.git-output.rename-to
+      captures:
+        1: keyword.other.rename-to.diff
+        2: string.unquoted.to-file.diff
+
+    # new file mode 100644
+    - match: ^(new file mode)\s+(\d+)$\n?
+      scope: meta.diff.header.git-output.new-file-mode
+      captures:
+        1: keyword.other.new-file-mode.diff
+        2: constant.numeric.integer.file-mode.diff
+
+    # deleted file mode 100644
+    - match: ^(deleted file mode)\s+(\d+)$\n?
+      scope: meta.diff.header.git-output.deleted-file-mode
+      captures:
+        1: keyword.other.deleted-file-mode.diff
+        2: constant.numeric.integer.file-mode.diff
 
     - match: ^(-{3}) (a/)?(.+)$\n?
       comment: |

--- a/syntax/test/syntax_test_diff.txt
+++ b/syntax/test/syntax_test_diff.txt
@@ -1,11 +1,37 @@
 # SYNTAX TEST "Packages/GitSavvy/syntax/diff.sublime-syntax"
 
 diff --git a/core/git_mixins/tags.py b/core/git_mixins/tags.py
-# ^ punctuation.definition.command.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.command
+#^^^ keyword.other.command.diff
+#          ^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.from-file.diff
+#                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.to-file.diff
 index a59222e..d6d3a74 100644
-# ^ punctuation.definition.index.diff
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.index
+#^^^^ keyword.other.index.diff
+#     ^^^^^^^ constant.numeric.hex.from-commit.diff
+#            ^^ punctuation.separator.sequence.diff
+#              ^^^^^^^ constant.numeric.hex.to-commit.diff
+#                      ^^^^^^ constant.numeric.integer.file-mode.diff
+deleted file mode 100644
+#^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.deleted-file-mode
+#^^^^^^^^^^^^^^^^ keyword.other.deleted-file-mode.diff
+#                 ^^^^^^ constant.numeric.integer.file-mode.diff
 new file mode 100644
-# ^ punctuation.definition.new-file-mode.diff
+#^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.new-file-mode
+#^^^^^^^^^^^^ keyword.other.new-file-mode.diff
+#             ^^^^^^ constant.numeric.integer.file-mode.diff
+rename from a/core/git_mixins/tags.py
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.rename-from
+#^^^^^^^^^^ keyword.other.rename-from.diff
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.from-file.diff
+rename to b/core/git_mixins/tags.py
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.rename-to
+#^^^^^^^^ keyword.other.rename-to.diff
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.to-file.diff
+similarity index 59%
+#^^^^^^^^^^^^^^^^^^^^ meta.diff.header.git-output.similarity-index
+#^^^^^^^^^^^^^^^ keyword.other.similarity-index.diff
+#                ^^^ constant.numeric.integer.similarity-index.diff
 
 --- /dev/null
 # <- punctuation.definition.from-file.diff


### PR DESCRIPTION
This commit addresses the following flaws of the diff.sublime-syntax

  1. missing rules for git output:
     - deleted file mode
     - rename from
     - rename to
     - similarity index

  2. the whole git output is scoped as as `punctuation`

  3. the linefeed \n is not included in the git output rules which
     causes bad results if a color scheme wants to highlight the
     background of the git output.

This commit therefore

  1. adds rules for the missing output messages
  2. introduces normal keyword, constant, string scopes for the output
     and encapsulates everything in a meta scope based on the existing
     `meta.diff.header` for easier color-scheme creation.
  3. optionally includes the \n? in any rule.

Hotfixes should be submitted to `master` branch. As part of the PR process,
you will be asked to provide the information necessary to make that happen.

Pull requests on new features should be submitted to `dev` branch and will be
regularly merged into `master` after evaluations over an extended period of
time.

The goal is to be able to create color schemes with nice looking git diff headers.

![screenshot](https://user-images.githubusercontent.com/16542113/45598857-7c107180-b9e2-11e8-86ee-7d841366d44b.png)
