### PR TITLE
Enhancement: cleanup commit message

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -315,6 +315,12 @@
     "confirm_force_push": true,
 
     /*
+        This setting controls how commit messages are cleaned up in the commit view:
+        `git commit --cleanup=<mode>`. It is ignored if `git config commit.cleanup` is set.
+    */
+    "commit_cleanup_default_mode": "strip",
+
+    /*
         When set to `true`, closing the commit message window via keyboard will result
         in a commit action being taken, except in cases where the message is empty.
         The same is also true for amending commits.


### PR DESCRIPTION
The cleanup flag controls how a commit message is cleaned up.
https://git-scm.com/docs/git-commit/2.0.0#git-commit---cleanupltmodegt

In command line, the default mode strips out comments started with `#` if an editor is opened interactively. However, GitSavvy only passes the message to the stdin, and the default mode only strips `whitespace`. This PR is trying to reflect the very same behavior on cli.