### PR TITLE
Bugfix: avoid splitlines in blame

### DIFF
--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -250,6 +250,9 @@ class GsBlameRefreshCommand(BlameMixin, TextCommand, GitCommand):
         return spacer.join(partitions_with_commits_iter)
 
     def parse_blame(self, blame_porcelain):
+        if blame_porcelain[-1] == '':
+            blame_porcelain = blame_porcelain[:-1]
+
         lines_iter = iter(blame_porcelain)
 
         blamed_lines = []

--- a/core/commands/blame.py
+++ b/core/commands/blame.py
@@ -214,7 +214,7 @@ class GsBlameRefreshCommand(BlameMixin, TextCommand, GitCommand):
             commit_hash, "--", filename_at_commit
         )
         blame_porcelain = unicodedata.normalize('NFC', blame_porcelain)
-        blamed_lines, commits = self.parse_blame(blame_porcelain.splitlines())
+        blamed_lines, commits = self.parse_blame(blame_porcelain.split('\n'))
 
         commit_infos = {
             commit_hash: self.short_commit_info(commit)


### PR DESCRIPTION
This avoid additional "line break" symbols in source code from being considered as line breaks in our parser. Git seems to only ever `'\n'` as a newline character, but python's `splitlines()` method considers many others by default.

Refs:
https://github.com/python/cpython/blob/3.4/Objects/unicodetype_db.h#L4317-L4338
https://github.com/git/git/blob/master/blame.c#L1633-L1637

Fixes #1011  (more info there)