### PR TITLE
Enhancement: better close commit handler

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -21,14 +21,6 @@
             { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
         ]
     },
-    {
-        "keys": ["ctrl+w"],
-        "command": "gs_commit_view_close",
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true }
-        ]
-    },
 
     ///////////////
     // DIFF VIEW //

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -21,14 +21,6 @@
             { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
         ]
     },
-    {
-        "keys": ["super+w"],
-        "command": "gs_commit_view_close",
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true }
-        ]
-    },
 
     ///////////////
     // DIFF VIEW //

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -21,14 +21,6 @@
             { "key": "setting.git_savvy.get_long_text_view", "operator": "equal", "operand": true }
         ]
     },
-    {
-        "keys": ["ctrl+w"],
-        "command": "gs_commit_view_close",
-        "context": [
-            { "key": "setting.command_mode", "operator": "equal", "operand": false },
-            { "key": "setting.git_savvy.commit_view", "operator": "equal", "operand": true }
-        ]
-    },
 
     ///////////////
     // DIFF VIEW //


### PR DESCRIPTION
As proposed in #1010 , this commit adds an `on_pre_close` handler that fires whenever sublime closes the commit view (identified by the view setting).

Unfortunately, the handler cannot prevent the view from closing, so this change adds a clone method that is called when we want to keep the commit window open. Moreover, since close also occurs when we actually commit, we need to make sure we allow the close to go through, even if `prompt_on_abort_commit` is turned on. This is achieved by setting `git_savvy.commit_view` to `False` after completing the commit.

Would appreciate if you could review and test this PR, as it's the first time I've written an event handler in sublime.