### PR TITLE
GPG no-tty helper script and options

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -184,12 +184,27 @@
 
     /*
         For each command specified, always include the command line flags
-        indicated in the global_flags hash.
+        indicated in the global_flags option AFTER the command.
      */
     "global_flags": {
         // --no-columns is not supported in Git versions <1.7.11.  If Git is configured
         //   to use columns globally, --no-columns should be added here.
         // "branch": ["--no-columns"]
+        //
+        // or, configure a GPG key to sign commits with a given key
+        // "commit": ["-S", "--gpg-sign=<key-id>"]
+    },
+
+    /*
+        For each command specified, always include the command line flags
+        indicated in the global_flags option BEFORE the command.
+     */
+    "global_pre_flags": {
+        // for example, override settings via the "-c" option, e.g
+        // the following configures a gpg.program no-tty wrapper script
+        // "commit": ["-c", "gpg.program=./scripts/stgpg.sh"]
+        // and configure every commit to be signed with your key
+        // "commit": ["-c", "commit.gpgsign=true"]
     },
 
     /*

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -480,9 +480,15 @@ class GitCommand(StatusMixin,
         git_cmd, *addl_args = args
 
         global_flags = self.savvy_settings.get("global_flags")
+        global_pre_flags = self.savvy_settings.get("global_pre_flags")
 
         if global_flags and git_cmd in global_flags:
             args = [git_cmd] + global_flags[git_cmd] + addl_args
+        else:
+            args = [git_cmd] + list(addl_args)
+
+        if global_pre_flags and git_cmd in global_pre_flags:
+            args = global_pre_flags[git_cmd] + args
 
         return args
 

--- a/docs/commit.md
+++ b/docs/commit.md
@@ -52,18 +52,18 @@ GitHub has instructions on [how to add your GPG key to GitHub](https://help.gith
 
 ## Sign your commits automatically
 
-If you always want to sign your commits you can configure git globally or in your project:
+If you always want to sign your commits with a GPG key you can configure git globally, locally in your git repo or using the `global_pre_flags` setting.:
 
 `git config (--global) commit.gpgsign true`
 
-Now when you commit with GitSavvy, your commit will be automatically signed due to the git configuration.
+When you commit with GitSavvy it will attempt to sign your commit. If your key hasn't been unlocked yet with your passphrase you will be asked for it (see more on credentials below).
 
-## Unlock your GPG key
+For more information, see [official git docs on the subject](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work).
 
-Next you want to tell git to ask for your passphrase through the gui. You can do this by setting the `askpass` variable:
+## Providing credentials to git
 
-`git config (--global) core.askpass git-gui--askpass`
+GitSavvy does not support prompting a user for credentials (there is no way, known to us, to forward the password securely to git). In order to tell git to ask for your passphrase through the OS gui, you can set the `askPass` variable in your config, e.g:
 
-I added my GPG to my keychain so it is unlocked when I log in as a user.
+`git config (--global) core.askPass git-gui--askpass`
 
-When you commit with GitSavvy it will attempt to sign your commit. If your key hasn't been unlocked yet with your passphrase you should now have a gui asking for it.
+For more information, see [official git docs on the subject](https://git-scm.com/docs/gitcredentials).

--- a/scripts/stgpg.sh
+++ b/scripts/stgpg.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# kudos to SourceTree for providing us with this idea
+# use --batch and --no-tty to avoid the terminal
+gpg2 --batch --no-tty "$@"


### PR DESCRIPTION
As in #596, this change documents a proper GPG setup on tty-enabled OS (Linux/MacOS), and correct credentials docs. This commit also adds the `global_pre_flags` setting to allow specifying options `BEFORE` the command, such as [the "-c" git per-command config option](https://git-scm.com/docs/git#git--cltnamegtltvaluegt).

The GPG prompt will only work in Sublime if user sets up `git config` with the options:
```
gpg.program=./scripts/stgpg.sh
commit.gpgsign=true
```

or instead of last one, passes the `-S` flag to commit command. So, I added the options in the GitSavvy settings comments.

TODO / Discuss:
- [ ] Figure how to use the script file from the packaged zip. Maybe create the file in the User folder on launch?
- [ ] Should we do this by default? Or only if user specifies an option? Or leave it in settings / docs?
- [ ] gpg-agent could freeze (happened to me while importing a key), breaking the whole commit flow, until it's killed. Should we take responsibility for this and warn users?
