### PR TITLE
Optimize status interface

### DIFF
--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -69,6 +69,7 @@ class GsHandleVintageousCommand(TextCommand):
         if savvy_settings.get("vintageous_friendly", False) is True:
             self.view.settings().set("git_savvy.vintageous_friendly", True)
             if savvy_settings.get("vintageous_enter_insert_mode", False) is True:
+                self.view.settings().set("vintageous_reset_mode_when_switching_tabs", False)
                 self.view.run_command("_enter_insert_mode")
 
 

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -20,7 +20,7 @@ IndexedEntry.__new__.__defaults__ = (None, ) * 8
 class StatusMixin():
 
     def _get_status(self):
-        return self.git("status", "--porcelain", "-z", "-b").split("\x00")
+        return self.git("status", "--porcelain", "-z", "-b").rstrip("\x00").split("\x00")
 
     def _parse_status_for_file_statuses(self, lines):
         porcelain_entries = lines[1:].__iter__()

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -19,16 +19,11 @@ IndexedEntry.__new__.__defaults__ = (None, ) * 8
 
 class StatusMixin():
 
-    def get_status(self):
-        """
-        Return a list of FileStatus objects.  These objects correspond
-        to all files that are 1) staged, 2) modified, 3) new, 4) deleted,
-        5) renamed, or 6) copied as well as additional status information that can
-        occur mid-merge.
-        """
-        stdout = self.git("status", "--porcelain", "-z")
+    def _get_status(self):
+        return self.git("status", "--porcelain", "-z", "-b").split("\x00")
 
-        porcelain_entries = stdout.split("\x00").__iter__()
+    def _parse_status_for_file_statuses(self, lines):
+        porcelain_entries = lines[1:].__iter__()
         entries = []
 
         for entry in porcelain_entries:
@@ -41,6 +36,17 @@ class StatusMixin():
             entries.append(FileStatus(path, path_alt, index_status, working_status))
 
         return entries
+
+    def get_status(self):
+        """
+        Return a list of FileStatus objects.  These objects correspond
+        to all files that are 1) staged, 2) modified, 3) new, 4) deleted,
+        5) renamed, or 6) copied as well as additional status information that can
+        occur mid-merge.
+        """
+
+        lines = self._get_status()
+        return self._parse_status_for_file_statuses(lines)
 
     def _get_indexed_entry(self, raw_entry):
         """

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -124,6 +124,9 @@ class StatusInterface(ui.Interface, GitCommand):
     """
 
     def __init__(self, *args, **kwargs):
+        if self._initialized:
+            return
+
         self.conflicts_keybindings = \
             "\n".join(line[2:] for line in self.conflicts_keybindings.split("\n"))
         self.state = {

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -158,6 +158,21 @@ class StatusInterface(ui.Interface, GitCommand):
             'stashes': self.get_stashes()
         })
 
+    def render(self, nuke_cursors=False):
+        self.pre_render()
+        self.just_render(nuke_cursors)
+
+        if hasattr(self, "reset_cursor") and nuke_cursors:
+            self.reset_cursor()
+
+    def just_render(self, nuke_cursors):
+        self.clear_regions()
+        rendered = self._render_template()
+        self.view.run_command("gs_new_content_and_regions", {
+            "content": rendered,
+            "regions": self.regions,
+            "nuke_cursors": nuke_cursors
+        })
 
     def on_new_dashboard(self):
         self.view.run_command("gs_status_navigate_file")

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -179,7 +179,7 @@ class StatusInterface(ui.Interface, GitCommand):
 
     def call_then_render(self, fn):
         fn()
-        self.just_render(nuke_cursors=False)
+        self.just_render()
 
     def render(self, nuke_cursors=False):
         self.pre_render()
@@ -189,7 +189,7 @@ class StatusInterface(ui.Interface, GitCommand):
             self.reset_cursor()
 
     @distinct_until_state_changed
-    def just_render(self, nuke_cursors):
+    def just_render(self, nuke_cursors=False):
         self.clear_regions()
         rendered = self._render_template()
         self.view.run_command("gs_new_content_and_regions", {
@@ -219,7 +219,7 @@ class StatusInterface(ui.Interface, GitCommand):
 
     def refresh_repo_status_and_render(self):
         self.refresh_repo_status()
-        self.just_render(nuke_cursors=False)
+        self.just_render()
 
     def on_new_dashboard(self):
         self.view.run_command("gs_status_navigate_file")

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -174,6 +174,20 @@ class StatusInterface(ui.Interface, GitCommand):
             "nuke_cursors": nuke_cursors
         })
 
+    def refresh_and_render_file_statuses(self):
+        (staged_entries,
+         unstaged_entries,
+         untracked_entries,
+         conflict_entries) = self.sort_status_entries(self.get_status())
+
+        self.state.update({
+            'staged_entries': staged_entries,
+            'unstaged_entries': unstaged_entries,
+            'untracked_entries': untracked_entries,
+            'conflict_entries': conflict_entries,
+        })
+        self.just_render(nuke_cursors=False)
+
     def on_new_dashboard(self):
         self.view.run_command("gs_status_navigate_file")
 
@@ -421,8 +435,9 @@ class GsStatusStageFileCommand(TextCommand, GitCommand):
         if file_paths:
             for fpath in file_paths:
                 self.stage_file(fpath, force=False)
+
             self.view.window().status_message("Staged files successfully.")
-            util.view.refresh_gitsavvy(self.view)
+            interface.refresh_and_render_file_statuses()
 
 
 class GsStatusUnstageFileCommand(TextCommand, GitCommand):
@@ -447,7 +462,7 @@ class GsStatusUnstageFileCommand(TextCommand, GitCommand):
             for fpath in file_paths:
                 self.unstage_file(fpath)
             self.view.window().status_message("Unstaged files successfully.")
-            util.view.refresh_gitsavvy(self.view)
+            interface.refresh_and_render_file_statuses()
 
 
 class GsStatusDiscardChangesToFileCommand(TextCommand, GitCommand):
@@ -530,7 +545,8 @@ class GsStatusStageAllFilesCommand(TextCommand, GitCommand):
 
     def run(self, edit):
         self.add_all_tracked_files()
-        util.view.refresh_gitsavvy(self.view)
+        interface = ui.get_interface(self.view.id())
+        interface.refresh_repo_status_and_render()
 
 
 class GsStatusStageAllFilesWithUntrackedCommand(TextCommand, GitCommand):
@@ -541,7 +557,8 @@ class GsStatusStageAllFilesWithUntrackedCommand(TextCommand, GitCommand):
 
     def run(self, edit):
         self.add_all_files()
-        util.view.refresh_gitsavvy(self.view)
+        interface = ui.get_interface(self.view.id())
+        interface.refresh_repo_status_and_render()
 
 
 class GsStatusUnstageAllFilesCommand(TextCommand, GitCommand):
@@ -552,7 +569,8 @@ class GsStatusUnstageAllFilesCommand(TextCommand, GitCommand):
 
     def run(self, edit):
         self.unstage_all_files()
-        util.view.refresh_gitsavvy(self.view)
+        interface = ui.get_interface(self.view.id())
+        interface.refresh_repo_status_and_render()
 
 
 class GsStatusDiscardAllChangesCommand(TextCommand, GitCommand):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -153,6 +153,7 @@ class StatusInterface(ui.Interface, GitCommand):
             'merge_conflicts': [],
             'branch_status': '',
             'git_root': '',
+            'show_help': True,
             'head': '',
             'stashes': []
         }
@@ -181,6 +182,7 @@ class StatusInterface(ui.Interface, GitCommand):
         # These are cheap to compute, so we just do it!
         self.update_state({
             'git_root': self.short_repo_path,
+            'show_help': not self.view.settings().get("git_savvy.help_hidden")
         })
 
     def update_state(self, data, then=None):
@@ -329,12 +331,11 @@ class StatusInterface(ui.Interface, GitCommand):
 
     @ui.partial("help")
     def render_help(self):
-        help_hidden = self.view.settings().get("git_savvy.help_hidden")
-        if help_hidden:
+        show_help = self.state['show_help']
+        if not show_help:
             return ""
-        else:
-            return self.template_help.format(
-                conflicts_bindings=self.render_conflicts_bindings())
+
+        return self.template_help.format(conflicts_bindings=self.render_conflicts_bindings())
 
 
 ui.register_listeners(StatusInterface)

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -142,16 +142,8 @@ class StatusInterface(ui.Interface, GitCommand):
         return "STATUS: {}".format(os.path.basename(self.repo_path))
 
     def pre_render(self):
-        (staged_files,
-         unstaged_files,
-         untracked_files,
-         merge_conflicts) = self.sort_status_entries(self.get_status())
-
+        self.refresh_file_statuses()
         self.state.update({
-            'staged_files': staged_files,
-            'unstaged_files': unstaged_files,
-            'untracked_files': untracked_files,
-            'merge_conflicts': merge_conflicts,
             'branch_status': self.get_branch_status(delim="\n           "),
             'git_root': self.short_repo_path,
             'head': self.get_latest_commit_msg_for_head(),
@@ -174,7 +166,7 @@ class StatusInterface(ui.Interface, GitCommand):
             "nuke_cursors": nuke_cursors
         })
 
-    def refresh_and_render_file_statuses(self):
+    def refresh_file_statuses(self):
         (staged_files,
          unstaged_files,
          untracked_files,
@@ -186,6 +178,9 @@ class StatusInterface(ui.Interface, GitCommand):
             'untracked_files': untracked_files,
             'merge_conflicts': merge_conflicts,
         })
+
+    def refresh_and_render_file_statuses(self):
+        self.refresh_file_statuses()
         self.just_render(nuke_cursors=False)
 
     def on_new_dashboard(self):

--- a/syntax/dashboard.sublime-syntax
+++ b/syntax/dashboard.sublime-syntax
@@ -35,7 +35,7 @@ contexts:
           comment: ahead or behind
           scope: keyword.other.git-savvy.summary-header.ahead-behind
 
-        - match: ^  (HEAD:)\s+([0-9a-f]{7,40}) .+
+        - match: ^  (HEAD:)(?:\s+([0-9a-f]{7,40}) .+)?
           comment: head summary
           scope: comment.git-savvy.summary-header.head-summary
           captures:

--- a/syntax/test/syntax_test_dashboard.txt
+++ b/syntax/test/syntax_test_dashboard.txt
@@ -15,6 +15,9 @@
 #  ^ comment
 #            ^ constant.other
 #  ^ comment.git-savvy.summary-header.title.head
+  HEAD:
+#  ^ comment
+# ^^^^^ comment.git-savvy.summary-header.title.head
 
   ** Press [e] to toggle display of remote branches. **
 # <- - meta.git-savvy.status


### PR DESCRIPTION
Fixes #1032 

DONE: 

- short-circuit staging/unstaging files (still not optimistic)
- render view as data arrives, whereby `git stash list` has the lowest priority
- optimize `git status` calls
- only draw when view changed

TODO:

- ~~Optimize `git status` calls~~
- ~~User looses selections / not multiple cursors but selected ranges collapse after each render~~ (This is actually implemented in `GsNewContentAndRegionsCommand` so I don't touch that) 
- ~~Only re-render if state actually changes / this should be trivial now since the actual render is a pure function on `state`~~

