### PR TITLE
Fix travis osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ env:
 
 matrix:
     include:
-        - os: linux
+        - name: Linux
+          os: linux
           language: python
           python: 3.3
-        - os: osx
+        - name: OSX
+          os: osx
           language: generic
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ before_install:
 install:
     - sh travis.sh bootstrap
     - sh travis.sh install_package_control
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-            brew update;
-            brew install python || brew upgrade python;
-      fi
     - pip3 install python-coveralls pycodestyle;
 
 script:


### PR DESCRIPTION
The (currently failing) `brew update` dance is not necessary anymore. We just skip it, they ship py36 which is enough.