### PR TITLE
Show toggle remotes help message only if there are any remotes

### DIFF
--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -92,10 +92,11 @@ class TagsInterface(ui.Interface, GitCommand):
             self.max_items = self.savvy_settings.get("max_items_in_tags_dashboard", None)
 
         self.local_tags = self.get_tags(reverse=True)
-        if not self.remotes and self.show_remotes:
-            self.remotes = self.get_remotes()
-            for name, uri in self.remotes.items():
-                self.remotes[name] = {"uri": uri}
+        if self.remotes is None:
+            self.remotes = {
+                name: {"uri": uri}
+                for name, uri in self.get_remotes().items()
+            }
 
     def on_new_dashboard(self):
         self.view.run_command("gs_tags_navigate_tag")
@@ -124,11 +125,11 @@ class TagsInterface(ui.Interface, GitCommand):
 
     @ui.partial("remote_tags")
     def render_remote_tags(self):
+        if not self.remotes:
+            return "\n"
+
         if not self.show_remotes:
             return self.render_remote_tags_off()
-
-        if not self.remotes:
-            return NO_REMOTES_MESSAGE
 
         output_tmpl = "\n"
         render_fns = []

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -10,7 +10,7 @@ from ...common import util
 
 TAG_DELETE_MESSAGE = "Tag(s) deleted."
 
-NO_REMOTES_MESSAGE = "You have not configured any remotes."
+NO_REMOTES_MESSAGE = "\n\n  You have not configured any remotes.\n"
 
 NO_LOCAL_TAGS_MESSAGE = "    Your repository has no tags."
 NO_REMOTE_TAGS_MESSAGE = "    Unable to retrieve tags for this remote."
@@ -127,7 +127,7 @@ class TagsInterface(ui.Interface, GitCommand):
         if not self.show_remotes:
             return self.render_remote_tags_off()
 
-        if self.remotes == []:
+        if not self.remotes:
             return NO_REMOTES_MESSAGE
 
         output_tmpl = "\n"

--- a/core/interfaces/tags.py
+++ b/core/interfaces/tags.py
@@ -10,7 +10,7 @@ from ...common import util
 
 TAG_DELETE_MESSAGE = "Tag(s) deleted."
 
-NO_REMOTES_MESSAGE = "\n\n  You have not configured any remotes.\n"
+NO_REMOTES_MESSAGE = "You have not configured any remotes."
 
 NO_LOCAL_TAGS_MESSAGE = "    Your repository has no tags."
 NO_REMOTE_TAGS_MESSAGE = "    Unable to retrieve tags for this remote."


### PR DESCRIPTION
Fixes #1046 

Because showing `** Press [e] to toggle display of remote branches. **` is lame when no remotes have been configured, we just suppress this help message in such cases.
