### PR TITLE
Improve graph view

### DIFF
--- a/common/commands/view_manipulation.py
+++ b/common/commands/view_manipulation.py
@@ -30,8 +30,13 @@ class GsReplaceViewTextCommand(TextCommand):
     a single cursor at the start of the file.
     """
 
-    def run(self, edit, text, nuke_cursors=False):
+    def run(self, edit, text, nuke_cursors=False, restore_cursors=False):
         cursors_num = len(self.view.sel())
+
+        if restore_cursors:
+            save_cursors = [self.view.rowcol(s.a) for s in self.view.sel()]
+            self.view.sel().clear()
+
         is_read_only = self.view.is_read_only()
         self.view.set_read_only(False)
         self.view.replace(edit, sublime.Region(0, self.view.size()), text)
@@ -42,6 +47,12 @@ class GsReplaceViewTextCommand(TextCommand):
             selections.clear()
             pt = sublime.Region(0, 0)
             selections.add(pt)
+
+        elif restore_cursors:
+            self.view.sel().clear()
+            for (row, col) in save_cursors:
+                cursor = self.view.text_point(row, col)
+                self.view.sel().add(cursor)
 
 
 class GsReplaceRegionCommand(TextCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -90,6 +90,22 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
         draw_info_panel(self.view, self.savvy_settings.get("graph_show_more_commit_info"))
 
 
+class GsLogGraphCommand(GsLogCommand):
+    """
+    Defines the main menu if you invoke `git: graph` or `git: graph current file`.
+
+    Accepts `current_file: bool` or `file_path: str` as (keyword) arguments, and
+    ensures that each of the defined actions/commands in `default_actions` are finally
+    called with `file_path` set.
+    """
+    default_actions = [
+        ["gs_log_graph_current_branch", "For current branch"],
+        ["gs_log_graph_all_branches", "For all branches"],
+        ["gs_log_graph_by_author", "Filtered by author"],
+        ["gs_log_graph_by_branch", "Filtered by branch"],
+    ]
+
+
 class GsLogGraphCurrentBranch(LogGraphMixin, WindowCommand, GitCommand):
     pass
 
@@ -157,15 +173,6 @@ class GsLogGraphByBranchCommand(LogGraphMixin, WindowCommand, GitCommand):
         args = super().get_graph_args()
         args.append(self._selected_branch)
         return args
-
-
-class GsLogGraphCommand(GsLogCommand):
-    default_actions = [
-        ["gs_log_graph_current_branch", "For current branch"],
-        ["gs_log_graph_all_branches", "For all branches"],
-        ["gs_log_graph_by_author", "Filtered by author"],
-        ["gs_log_graph_by_branch", "Filtered by branch"],
-    ]
 
 
 class GsLogGraphNavigateCommand(GsNavigate):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -182,12 +182,11 @@ class GsLogGraphActionCommand(GsLogActionCommand):
     ]
 
     def update_actions(self):
-        super().update_actions()
+        super().update_actions()  # GsLogActionCommand will mutate actions if `_file_path` is set!
         view = self.window.active_view()
         if view.settings().get("git_savvy.log_graph_view"):
             if self._file_path:
-                # for `git: graph current file`, two more options would be inserted
-                # at index 1
+                # for `git: graph current file`
                 self.actions.insert(5, ["revert_commit", "Revert commit"])
             else:
                 self.actions.insert(3, ["revert_commit", "Revert commit"])

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -237,7 +237,8 @@ def draw_info_panel_for_line(wid, line_text, show_panel):
 
         window.run_command("gs_show_commit_info", {"commit_hash": commit_hash})
     else:
-        window.run_command("hide_panel")
+        if window.active_panel() == "output.show_commit_info":
+            window.run_command("hide_panel")
 
 
 class GsLogGraphToggleMoreInfoCommand(TextCommand, WindowCommand, GitCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -60,6 +60,9 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
+        sublime.set_timeout_async(self.run_async)
+
+    def run_async(self):
         file_path = self.file_path
         if file_path:
             graph_content = "File: {}\n\n".format(file_path)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -168,55 +168,6 @@ class GsLogGraphCommand(GsLogCommand):
     ]
 
 
-class GsLogGraphActionCommand(GsLogActionCommand):
-
-    """
-    Checkout the commit at the selected line. It is also used by compare_commit_view.
-    """
-    default_actions = [
-        ["show_commit", "Show commit"],
-        ["checkout_commit", "Checkout commit"],
-        ["cherry_pick", "Cherry-pick commit"],
-        ["compare_against", "Compare commit against ..."],
-        ["copy_sha", "Copy the full SHA"]
-    ]
-
-    def update_actions(self):
-        super().update_actions()  # GsLogActionCommand will mutate actions if `_file_path` is set!
-        view = self.window.active_view()
-        if view.settings().get("git_savvy.log_graph_view"):
-            if self._file_path:
-                # for `git: graph current file`
-                self.actions.insert(5, ["revert_commit", "Revert commit"])
-            else:
-                self.actions.insert(3, ["revert_commit", "Revert commit"])
-
-            self.actions.extend([
-                ["diff_commit", "Diff commit"],
-                ["diff_commit_cache", "Diff commit (cached)"],
-            ])
-        elif view.settings().get("git_savvy.compare_commit_view"):
-            pass
-
-    def run(self):
-        view = self.window.active_view()
-
-        self.selections = view.sel()
-
-        lines = util.view.get_lines_from_regions(view, self.selections)
-        line = lines[0]
-
-        m = COMMIT_LINE.search(line)
-        self._commit_hash = m.groupdict()['commit_hash'] if m else ""
-        self._file_path = self.file_path
-
-        if not len(self.selections) == 1:
-            self.window.status_message("You can only do actions on one commit at a time.")
-            return
-
-        super().run(commit_hash=self._commit_hash, file_path=self._file_path)
-
-
 class GsLogGraphNavigateCommand(GsNavigate):
 
     """
@@ -287,3 +238,53 @@ class GsLogGraphToggleMoreInfoCommand(TextCommand, WindowCommand, GitCommand):
         show_panel = not self.savvy_settings.get("graph_show_more_commit_info")
         self.savvy_settings.set("graph_show_more_commit_info", show_panel)
         draw_info_panel(self.view, show_panel)
+
+
+class GsLogGraphActionCommand(GsLogActionCommand):
+
+    """
+    Define menu shown if you `<enter>` on a specific commit.
+    Also used by `compare_commit_view`.
+    """
+    default_actions = [
+        ["show_commit", "Show commit"],
+        ["checkout_commit", "Checkout commit"],
+        ["cherry_pick", "Cherry-pick commit"],
+        ["compare_against", "Compare commit against ..."],
+        ["copy_sha", "Copy the full SHA"]
+    ]
+
+    def update_actions(self):
+        super().update_actions()  # GsLogActionCommand will mutate actions if `_file_path` is set!
+        view = self.window.active_view()
+        if view.settings().get("git_savvy.log_graph_view"):
+            if self._file_path:
+                # for `git: graph current file`
+                self.actions.insert(5, ["revert_commit", "Revert commit"])
+            else:
+                self.actions.insert(3, ["revert_commit", "Revert commit"])
+
+            self.actions.extend([
+                ["diff_commit", "Diff commit"],
+                ["diff_commit_cache", "Diff commit (cached)"],
+            ])
+        elif view.settings().get("git_savvy.compare_commit_view"):
+            pass
+
+    def run(self):
+        view = self.window.active_view()
+
+        self.selections = view.sel()
+
+        lines = util.view.get_lines_from_regions(view, self.selections)
+        line = lines[0]
+
+        m = COMMIT_LINE.search(line)
+        self._commit_hash = m.groupdict()['commit_hash'] if m else ""
+        self._file_path = self.file_path
+
+        if not len(self.selections) == 1:
+            self.window.status_message("You can only do actions on one commit at a time.")
+            return
+
+        super().run(commit_hash=self._commit_hash, file_path=self._file_path)

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -31,14 +31,19 @@ class LogGraphMixin(object):
     def run_async(self):
         # need to get repo_path before the new view is created.
         repo_path = self.repo_path
+
         view = util.view.get_scratch_view(self, "log_graph", read_only=True)
+        view.set_syntax_file("Packages/GitSavvy/syntax/graph.sublime-syntax")
+        view.run_command("gs_handle_vintageous")
+        view.run_command("gs_handle_arrow_keys")
+        view.sel().clear()
+
         settings = view.settings()
         settings.set("git_savvy.repo_path", repo_path)
         settings.set("git_savvy.file_path", self._file_path)
         settings.set("git_savvy.git_graph_args", self.get_graph_args())
-        view.set_syntax_file("Packages/GitSavvy/syntax/graph.sublime-syntax")
         view.set_name(self.title)
-        view.sel().clear()
+
         view.run_command("gs_log_graph_refresh")
         view.run_command("gs_log_graph_navigate")
 
@@ -78,9 +83,6 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
 
         self.view.run_command("gs_replace_view_text", {"text": graph_content})
         self.view.run_command("gs_log_graph_more_info")
-
-        self.view.run_command("gs_handle_vintageous")
-        self.view.run_command("gs_handle_arrow_keys")
 
 
 class GsLogGraphCurrentBranch(LogGraphMixin, WindowCommand, GitCommand):

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -39,7 +39,6 @@ class LogGraphMixin(object):
         view.set_syntax_file("Packages/GitSavvy/syntax/graph.sublime-syntax")
         view.run_command("gs_handle_vintageous")
         view.run_command("gs_handle_arrow_keys")
-        view.sel().clear()
 
         settings = view.settings()
         settings.set("git_savvy.repo_path", repo_path)

--- a/core/commands/show_commit_info.py
+++ b/core/commands/show_commit_info.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import sublime
 from sublime_plugin import WindowCommand
 
@@ -13,19 +15,24 @@ class GsShowCommitInfoCommand(WindowCommand, GitCommand):
     def run_async(self):
         show_full = self.savvy_settings.get("show_full_commit_info")
         show_diffstat = self.savvy_settings.get("show_diffstat")
-        text = self.git(
-            "show",
-            "--no-color",
-            "--format=fuller",
-            "--stat" if show_diffstat else None,
-            "--patch" if show_full else None,
-            self._commit_hash,
-            "--" if self._file_path else None,
-            self._file_path if self._file_path else None
-        )
+        text = self.show_commit(self._commit_hash, self._file_path, show_diffstat, show_full)
+
         output_view = self.window.create_output_panel("show_commit_info")
         output_view.set_read_only(False)
         output_view.run_command("gs_replace_view_text", {"text": text, "nuke_cursors": True})
         output_view.set_syntax_file("Packages/GitSavvy/syntax/show_commit.sublime-syntax")
         output_view.set_read_only(True)
         self.window.run_command("show_panel", {"panel": "output.show_commit_info"})
+
+    @lru_cache(maxsize=64)
+    def show_commit(self, commit_hash, file_path, show_diffstat, show_full):
+        return self.git(
+            "show",
+            "--no-color",
+            "--format=fuller",
+            "--stat" if show_diffstat else None,
+            "--patch" if show_full else None,
+            commit_hash,
+            "--" if file_path else None,
+            file_path if file_path else None
+        )

--- a/tests/fixtures/log_graph_1.txt
+++ b/tests/fixtures/log_graph_1.txt
@@ -1,0 +1,16 @@
+* fec0aca (HEAD -> improve-graph-view) Respect any other way a user can hide or show a panel
+* f461ea1 Cache `git show ...` command as it's immutable
+* 1c6ff56 Fix: Only hide our own panel.
+* 3543eee Ensure to restore the cursors after drawing
+* c658951 Build actual git command on refresh
+* 5c6f063 Move `GsLogGraphCommand` and add comment
+* 5c15c8e Move `GsLogActionCommand` to bottom and fix comment
+* 00e7e61 Make a comment a bit clearer
+* 667cc20 Make the listener a `ViewEventListener`
+* 4bd960c Update info panel `on_selection_modified`
+* c08cd48 Navigate *after* first draw
+* 4496f75 Handle one-time side-effects after view creation
+* d0d4321 Make GsLogGraphRefreshCommand an async command
+*   57b00b1 (origin/dev, dev) Merge pull request #1033 from kaste/optimize-status-interface
+|\
+| * 0c2dd28 Guard updating state using a lock

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -257,5 +257,3 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view.run_command('gs_log_graph_navigate')
         log_view.run_command('gs_log_graph_navigate')
         yield 2000
-
-

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -115,12 +115,12 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
             'f461ea1': COMMIT_INFO_2
         })
 
-        return (
-            yield from self.create_graph_view_async(
-                REPO_PATH, LOG,
-                wait_for='0c2dd28 Guard updating state using a lock'
-            )
+        log_view = yield from self.create_graph_view_async(
+            REPO_PATH, LOG,
+            wait_for='0c2dd28 Guard updating state using a lock'
         )
+        yield lambda: self.window.active_panel() == 'output.show_commit_info'
+        return log_view
 
     def test_open_info_panel_after_create(self):
         log_view = yield from self.setup_graph_view_async()

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -138,6 +138,10 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view = yield from self.setup_graph_view_async()
         panel = self.window.find_output_panel('show_commit_info')
 
+        yield from self.await_string_in_view(panel, COMMIT_1)
+
+        # `yield condition` will continue after a timeout so we need
+        # to actually assert here
         actual = panel.find(COMMIT_1, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
@@ -148,8 +152,6 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view.run_command('gs_log_graph_navigate')
         yield from self.await_string_in_view(panel, COMMIT_2)
 
-        # `yield condition` will continue after a timeout so we need
-        # to actually assert here
         actual = panel.find(COMMIT_2, 0, sublime.LITERAL)
         self.assertTrue(actual)
 

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -25,6 +25,8 @@ else:
 
 
 THIS_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+COMMIT_1 = 'This is commit fec0aca'
+COMMIT_2 = 'This is commit f461ea1'
 
 
 def fixture(name):
@@ -113,12 +115,9 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         REPO_PATH = '/not/there'
         LOG = fixture('log_graph_1.txt')
 
-        COMMIT_INFO_1 = 'This is commit fec0aca'
-        COMMIT_INFO_2 = 'This is commit f461ea1'
-
         self.enable_commit_info({
-            'fec0aca': COMMIT_INFO_1,
-            'f461ea1': COMMIT_INFO_2
+            'fec0aca': COMMIT_1,
+            'f461ea1': COMMIT_2
         })
 
         log_view = yield from self.create_graph_view_async(
@@ -139,7 +138,7 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view = yield from self.setup_graph_view_async()
         panel = self.window.find_output_panel('show_commit_info')
 
-        actual = panel.find('fec0aca', 0, sublime.LITERAL)
+        actual = panel.find(COMMIT_1, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
     def test_info_panel_shows_second_commit_after_navigate(self):
@@ -147,11 +146,11 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         panel = self.window.find_output_panel('show_commit_info')
 
         log_view.run_command('gs_log_graph_navigate')
-        yield from self.await_string_in_view(panel, 'f461ea1')
+        yield from self.await_string_in_view(panel, COMMIT_2)
 
         # `yield condition` will continue after a timeout so we need
         # to actually assert here
-        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        actual = panel.find(COMMIT_2, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
     def test_info_panel_shows_second_commit_after_cursor_moves(self):
@@ -161,9 +160,9 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         log_view.sel().clear()
         log_view.sel().add(log_view.text_point(1, 14))
         GsLogGraphCursorListener().on_selection_modified_async(log_view)
-        yield from self.await_string_in_view(panel, 'f461ea1')
+        yield from self.await_string_in_view(panel, COMMIT_2)
 
-        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        actual = panel.find(COMMIT_2, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
     def test_if_the_user_issues_our_toggle_command_close_the_panel_and_keep_it(self):
@@ -226,9 +225,9 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         # show panel
         self.window.run_command('gs_log_graph_toggle_more_info')
 
-        yield from self.await_string_in_view(panel, 'f461ea1')
+        yield from self.await_string_in_view(panel, COMMIT_2)
 
-        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        actual = panel.find(COMMIT_2, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
     def test_show_correct_info_if_user_moves_around_and_then_opens_panel(self):
@@ -245,9 +244,9 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         # show panel e.g. via mouse
         self.window.run_command('show_panel', {'panel': 'output.show_commit_info'})
 
-        yield from self.await_string_in_view(panel, 'f461ea1')
+        yield from self.await_string_in_view(panel, COMMIT_2)
 
-        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        actual = panel.find(COMMIT_2, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
     def _test_afocus_info_panel(self):

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -1,0 +1,261 @@
+import os
+from textwrap import dedent
+
+import sublime
+
+from unittesting import DeferrableTestCase
+from GitSavvy.tests.mockito import unstub, when
+
+from GitSavvy.core.commands.log_graph import (
+    GsLogGraphCurrentBranch,
+    GsLogGraphRefreshCommand,
+    GsLogGraphCursorListener
+)
+from GitSavvy.core.commands.show_commit_info import GsShowCommitInfoCommand
+from GitSavvy.core.settings import GitSavvySettings
+
+if os.name == 'nt':
+    # On Windows, `find_all_results` returns pseudo linux paths
+    # E.g. `/C/not/here/README.md`
+    def cleanup_fpath(fpath):
+        return fpath[2:]
+else:
+    def cleanup_fpath(fpath):
+        return fpath
+
+
+THIS_DIRNAME = os.path.dirname(os.path.realpath(__file__))
+
+
+def fixture(name):
+    with open(os.path.join(THIS_DIRNAME, 'fixtures', name)) as f:
+        return f.read()
+
+
+class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
+    @classmethod
+    def setUpClass(cls):
+        # make sure we have a window to work with
+        original_window_id = sublime.active_window().id()
+        sublime.run_command("new_window")
+
+        yield lambda: sublime.active_window().id() != original_window_id
+
+        cls.window = sublime.active_window()
+
+        s = sublime.load_settings("Preferences.sublime-settings")
+        s.set("close_windows_when_empty", False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.window.run_command('close_window')
+
+    def setUp(self):
+        self.create_new_view()
+
+    def tearDown(self):
+        self.do_cleanup()
+        unstub()
+
+    # `addCleanup` doesn't work either in Sublime at all or
+    # with the DeferrableTestCase so we do a quick implementation
+    # here.
+    def add_cleanup(self, fn, *args, **kwargs):
+        self._cleanups.append((fn, args, kwargs))
+
+    def do_cleanup(self):
+        while self._cleanups:
+            fn, args, kwrags = self._cleanups.pop()
+            try:
+                fn(*args, **kwrags)
+            except Exception:
+                pass
+
+    def create_new_view(self, window=None):
+        view = (window or sublime.active_window()).new_file()
+        self.add_cleanup(self.close_view, view)
+        return view
+
+    def close_view(self, view):
+        if view:
+            view.set_scratch(True)
+            view.close()
+
+    def set_global_setting(self, key, value):
+        settings = GitSavvySettings()
+        original_value = settings.get(key)
+        settings.set(key, value)
+        self.add_cleanup(settings.set, key, original_value)
+
+    def enable_commit_info(self, info):
+        self.set_global_setting('graph_show_more_commit_info', True)
+        for sha1, info in info.items():
+            when(GsShowCommitInfoCommand).show_commit(sha1, ...).thenReturn(info)
+
+    def create_graph_view_async(self, repo_path, log, wait_for):
+        when(GsLogGraphRefreshCommand).git('log', ...).thenReturn(log)
+        cmd = GsLogGraphCurrentBranch(self.window)
+        when(cmd).get_repo_path().thenReturn(repo_path)
+        cmd.run()
+        yield lambda: self.window.active_view().settings().get('git_savvy.log_graph_view') is True
+        log_view = self.window.active_view()
+        yield lambda: log_view.find(wait_for, 0, sublime.LITERAL)
+
+        return log_view
+
+    def setup_graph_view_async(self):
+        REPO_PATH = '/not/there'
+        LOG = fixture('log_graph_1.txt')
+
+        COMMIT_INFO_1 = 'This is commit fec0aca'
+        COMMIT_INFO_2 = 'This is commit f461ea1'
+
+        self.enable_commit_info({
+            'fec0aca': COMMIT_INFO_1,
+            'f461ea1': COMMIT_INFO_2
+        })
+
+        return (
+            yield from self.create_graph_view_async(
+                REPO_PATH, LOG,
+                wait_for='0c2dd28 Guard updating state using a lock'
+            )
+        )
+
+    def test_open_info_panel_after_create(self):
+        log_view = yield from self.setup_graph_view_async()
+
+        actual = self.window.active_panel()
+        expected = 'output.show_commit_info'
+        self.assertEqual(actual, expected)
+
+    def test_info_panel_shows_first_commit_initially(self):
+        log_view = yield from self.setup_graph_view_async()
+        panel = self.window.find_output_panel('show_commit_info')
+
+        actual = panel.find('fec0aca', 0, sublime.LITERAL)
+        self.assertTrue(actual)
+
+    def test_info_panel_shows_second_commit_after_navigate(self):
+        log_view = yield from self.setup_graph_view_async()
+        panel = self.window.find_output_panel('show_commit_info')
+
+        log_view.run_command('gs_log_graph_navigate')
+        yield lambda: panel.find('f461ea1', 0, sublime.LITERAL)
+
+        # `yield condition` will continue after a timeout so we need
+        # to actually assert here
+        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        self.assertTrue(actual)
+
+    def test_info_panel_shows_second_commit_after_cursor_moves(self):
+        log_view = yield from self.setup_graph_view_async()
+        panel = self.window.find_output_panel('show_commit_info')
+
+        log_view.sel().clear()
+        log_view.sel().add(log_view.text_point(1, 14))
+        GsLogGraphCursorListener().on_selection_modified_async(log_view)
+        yield lambda: panel.find('f461ea1', 0, sublime.LITERAL)
+
+        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        self.assertTrue(actual)
+
+    def test_if_the_user_issues_our_toggle_command_close_the_panel_and_keep_it(self):
+        log_view = yield from self.setup_graph_view_async()
+
+        self.window.run_command('gs_log_graph_toggle_more_info')
+        actual = self.window.active_panel()
+        expected = None
+        self.assertEqual(actual, expected)
+
+        # Ensure it doesn't open on navigate
+        log_view.run_command('gs_log_graph_navigate')
+
+        yield 500  # ?
+
+        actual = self.window.active_panel()
+        expected = None
+        self.assertEqual(actual, expected)
+
+    def test_if_the_user_opens_another_panel_dont_fight(self):
+        window = self.window
+        log_view = yield from self.setup_graph_view_async()
+        active_group = window.active_group()
+
+        window.run_command('show_panel', {'panel': 'console'})
+        # We need both to get the cursor back
+        window.focus_group(active_group)
+        window.focus_view(log_view)
+        log_view.run_command('gs_log_graph_navigate')
+
+        yield 500  # ?
+
+        actual = self.window.active_panel()
+        expected = 'console'
+        self.assertEqual(actual, expected)
+
+    def test_if_the_user_closes_the_panel_accept_it(self):
+        log_view = yield from self.setup_graph_view_async()
+
+        self.window.run_command('hide_panel')
+        log_view.run_command('gs_log_graph_navigate')
+
+        yield 500  # ?
+
+        actual = self.window.active_panel()
+        expected = None
+        self.assertEqual(actual, expected)
+
+    def test_show_correct_info_if_user_moves_around_and_then_toggles_panel(self):
+        log_view = yield from self.setup_graph_view_async()
+        panel = self.window.find_output_panel('show_commit_info')
+        # close panel
+        self.window.run_command('gs_log_graph_toggle_more_info')
+
+        # move around
+        log_view.sel().clear()
+        log_view.sel().add(log_view.text_point(1, 14))
+        GsLogGraphCursorListener().on_selection_modified_async(log_view)
+
+        # show panel
+        self.window.run_command('gs_log_graph_toggle_more_info')
+
+        yield lambda: panel.find('f461ea1', 0, sublime.LITERAL)
+
+        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        self.assertTrue(actual)
+
+    def test_show_correct_info_if_user_moves_around_and_then_opens_panel(self):
+        log_view = yield from self.setup_graph_view_async()
+        panel = self.window.find_output_panel('show_commit_info')
+        # close panel
+        self.window.run_command('gs_log_graph_toggle_more_info')
+
+        # move around
+        log_view.sel().clear()
+        log_view.sel().add(log_view.text_point(1, 14))
+        GsLogGraphCursorListener().on_selection_modified_async(log_view)
+
+        # show panel e.g. via mouse
+        self.window.run_command('show_panel', {'panel': 'output.show_commit_info'})
+
+        yield lambda: panel.find('f461ea1', 0, sublime.LITERAL)
+
+        actual = panel.find('f461ea1', 0, sublime.LITERAL)
+        self.assertTrue(actual)
+
+    def _test_afocus_info_panel(self):
+        log_view = yield from self.setup_graph_view_async()
+
+        yield 2500
+
+    def _test(self):
+        panel = self.window.find_output_panel('show_commit_info')
+
+        self.window.focus_view(panel)
+
+        log_view.run_command('gs_log_graph_navigate')
+        log_view.run_command('gs_log_graph_navigate')
+        yield 2000
+
+


### PR DESCRIPTION
Fixes #1052 
Fixes #1053 
Fixes #1054 

PLUS:

- Commit info panel can be hidden via `<ESC>` or mouse
- Commit info panel can be shown via mouse
- Don't fight with other panels the user might open. E.g. find or console
- Cache `git show <commit>` calls

Let's see how this one goes. `commit_compare` is actually the same as graph, that was super confusing first. 🍭 

🚶 🍷  🛌 

~Needs https://github.com/divmain/GitSavvy/pull/1033/commits/50c68a323006ed00f76afda62c662913fc29e403 which is included in #1033 for vintagous~ #1033 has been merged