### PR TITLE
Fix: Allow closing the commit view if `prompt_on_abort_commit=false`

### DIFF
--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -402,3 +402,5 @@ class GsCommitViewCloseCommand(TextCommand, GitCommand):
 
             if ok:
                 self.view.close()
+        else:
+            self.view.close()


### PR DESCRIPTION
Fixes #1055

Regardless of what #1016 does or eventually will do, this needs a hotfix bc right now, the user can't close the commit view using `ctrl+w` if `prompt_on_abort_commit` is false.