### PR TITLE
Iterate on diff view

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -588,6 +588,15 @@
         ]
     },
     {
+        "keys": ["tab"],
+        "command": "gs_diff_toggle_setting",
+        "args": { "setting": "in_cached_mode" },
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }
+        ]
+    },
+    {
         "keys": ["s"],
         "command": "gs_diff_toggle_setting",
         "args": { "setting": "ignore_whitespace" },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -542,6 +542,15 @@
         ]
     },
     {
+        "keys": ["c"],
+        "command": "gs_status_commit",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_diff_navigate",
         "args": { "forward": true },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -551,6 +551,15 @@
         ]
     },
     {
+        "keys": ["C"],
+        "command": "gs_status_commit_unstaged",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
+    {
         "keys": ["."],
         "command": "gs_diff_navigate",
         "args": { "forward": true },

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -183,10 +183,20 @@ class GsDiffRefreshCommand(TextCommand, GitCommand):
 class GsDiffToggleSetting(TextCommand):
 
     """
-    Toggle view settings: `ignore_whitespace` or `show_word_diff`.
+    Toggle view settings: `ignore_whitespace` , `show_word_diff` or
+    `in_cached_mode`.
     """
 
     def run(self, edit, setting):
+        if (
+            setting == 'in_cached_mode'
+            and self.view.settings().get("git_savvy.diff_view.base_commit")
+            and self.view.settings().get("git_savvy.diff_view.target_commit")
+        ):
+            # There is no cached mode if you diff between two commits, so
+            # we need to abort here
+            return
+
         setting_str = "git_savvy.diff_view.{}".format(setting)
         settings = self.view.settings()
         settings.set(setting_str, not settings.get(setting_str))

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -175,7 +175,10 @@ class GsDiffRefreshCommand(TextCommand, GitCommand):
             raise err
 
         text = prelude + '\n--\n' + stdout
-        self.view.run_command("gs_replace_view_text", {"text": text})
+
+        self.view.run_command(
+            "gs_replace_view_text", {"text": text, "restore_cursors": True}
+        )
         if navigate_to_next_hunk:
             self.view.run_command("gs_diff_navigate")
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -197,11 +197,24 @@ class GsDiffToggleSetting(TextCommand):
             # we need to abort here
             return
 
-        setting_str = "git_savvy.diff_view.{}".format(setting)
         settings = self.view.settings()
+        last_cursors = []
+
+        if setting == 'in_cached_mode':
+            last_cursors = settings.get('git_savvy.diff_view.last_cursors') or []
+            cursors = [(s.a, s.b) for s in self.view.sel()]
+            settings.set('git_savvy.diff_view.last_cursors', cursors)
+
+        setting_str = "git_savvy.diff_view.{}".format(setting)
         settings.set(setting_str, not settings.get(setting_str))
         self.view.window().status_message("{} is now {}".format(setting, settings.get(setting_str)))
+
         self.view.run_command("gs_diff_refresh")
+        if last_cursors:
+            sel = self.view.sel()
+            sel.clear()
+            for (a, b) in last_cursors:
+                sel.add(sublime.Region(a, b))
 
 
 class GsDiffFocusEventListener(EventListener):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -218,6 +218,7 @@ class GsDiffToggleSetting(TextCommand):
             sel.clear()
             for (a, b) in last_cursors:
                 sel.add(sublime.Region(a, b))
+            self.view.show(sel)
 
 
 class GsDiffFocusEventListener(EventListener):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -99,7 +99,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
             if not title:
                 title = (DIFF_CACHED_TITLE if in_cached_mode else DIFF_TITLE).format(os.path.basename(repo_path))
             diff_view.set_name(title)
-            diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff.sublime-syntax")
+            diff_view.set_syntax_file("Packages/GitSavvy/syntax/diff_view.sublime-syntax")
             diff_views[view_key] = diff_view
 
         self.window.focus_view(diff_view)

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -16,8 +16,10 @@
 
 <h3>When Diffing Working Tree</h3>
 <ul>
+  <li><code><span class="shortcut-key">tab&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>switch between staged/unstaged area</code></li>
   <li><code><span class="shortcut-key">h / {super_key}-enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk / unstage hunk (in cached mode)</code></li>
   <li><code><span class="shortcut-key">H / {super_key}-backspace&nbsp;&nbsp;</span>reset hunk</code></li>
+  <li><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></li>
 </ul>
 
 <h3>Other</h3>

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -20,6 +20,7 @@
   <li><code><span class="shortcut-key">h / {super_key}-enter&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>stage hunk / unstage hunk (in cached mode)</code></li>
   <li><code><span class="shortcut-key">H / {super_key}-backspace&nbsp;&nbsp;</span>reset hunk</code></li>
   <li><code><span class="shortcut-key">c&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit</code></li>
+  <li><code><span class="shortcut-key">C&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>commit, including unstaged</code></li>
 </ul>
 
 <h3>Other</h3>

--- a/syntax/diff_view.sublime-syntax
+++ b/syntax/diff_view.sublime-syntax
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: GitSavvy Diff View
+hidden: true
+scope: git-savvy.diff_view
+first_line_match: |-
+  (?x)^
+      (===\ modified\ file
+      |==== \s* // .+ \s - \s .+ \s+ ====
+      |Index:[ ]
+      |---\ [^%]
+      |\*\*\*.*\d{4}\s*$
+      |\d+(,\d+)* (a|d|c) \d+(,\d+)* $
+      |diff\ --git[ ]
+      )
+contexts:
+  main:
+    - match: .
+      push: header
+
+  header:
+    - match: '^--$'
+      scope: comment
+      push:
+        - include: 'scope:git-savvy.diff'
+
+    - match: .*
+      scope: comment

--- a/syntax/diff_view.sublime-syntax
+++ b/syntax/diff_view.sublime-syntax
@@ -4,16 +4,6 @@
 name: GitSavvy Diff View
 hidden: true
 scope: git-savvy.diff_view
-first_line_match: |-
-  (?x)^
-      (===\ modified\ file
-      |==== \s* // .+ \s - \s .+ \s+ ====
-      |Index:[ ]
-      |---\ [^%]
-      |\*\*\*.*\d{4}\s*$
-      |\d+(,\d+)* (a|d|c) \d+(,\d+)* $
-      |diff\ --git[ ]
-      )
 contexts:
   main:
     - match: .

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -73,11 +73,19 @@ class TestDiffView(DeferrableTestCase):
         cmd.run_async()
 
         diff_view = self.window.active_view()
-        self.assertEqual(diff_view.substr(sublime.Region(0, diff_view.size())), DIFF)
+        BUFFER_CONTENT = diff_view.substr(sublime.Region(0, diff_view.size()))
+        self.assertEqual(
+            BUFFER_CONTENT,
+            '''
+  UNSTAGED CHANGES
+
+--
+''' + DIFF
+        )
 
         regex = diff_view.settings().get('result_file_regex')
 
-        matches = re.findall(regex, DIFF, re.M)
+        matches = re.findall(regex, BUFFER_CONTENT, re.M)
         expected = [
             'core/commands/custom.py',
             'core/commands/diff.py',
@@ -90,9 +98,10 @@ class TestDiffView(DeferrableTestCase):
         ]
         self.assertEqual(matches, expected)
 
-        matches = re.finditer(regex, DIFF, re.M)
+        PRELUDE_HEIGHT = 4
+        matches = re.finditer(regex, BUFFER_CONTENT, re.M)
         actual = [
-            (m.group(0), diff_view.rowcol(m.span(1)[0])[0] + 1)
+            (m.group(0), diff_view.rowcol(m.span(1)[0])[0] + 1 - PRELUDE_HEIGHT)
             # Oh boy, a oneliner.          ^^^^^^^^^^^^ start offset
             #                      ^^^^^^ convert to (row, col)
             #                                          ^^^^^^^ only take row


### PR DESCRIPTION
This is pretty much to get early feedback. I saw #856 and implemented it. The keybinding I used is `<tab>` to quickly switch between *cached* and *non-cached* (in git parlance) mode. 

`<tab>` is convenient, however, if we ever want to use 'diff all files' as a dashboard view it would clash with our 'cycle views' command.

I also added a basic header/prelude to the diff view. This is similar to the prelude we have e.g. in the status dashboard. And I think it's really easier to grasp what the view is currently showing. (Esp. with the implemented fast toggle.) It currently shows the file you're diffing if any, the two commits you're comparing if any. For the typical `git diff` it tells you either 'UNSTAGED CHANGES' or 'STAGED CHANGES (Will commit)'. This is the exact wording git GUI uses, and avoids the more technically, usually confusing 'cached' terminology.  

I added a LOL-naive syntax. (Honestly, it did not click yet how these syntax files work, and so it is worse than writing CSS for me.)

