### PR TITLE
Fix: don't ansi-decode a binary string

### DIFF
--- a/core/git_command.py
+++ b/core/git_command.py
@@ -269,7 +269,7 @@ class GitCommand(StatusMixin,
                 raise GitSavvyError(
                     "`{}` failed.".format(command_str), show_panel=show_panel_on_stderr)
 
-        if stdout:
+        if stdout and decode:
             stdout = ANSI_ESCAPE.sub('', stdout)
 
         return stdout


### PR DESCRIPTION
If we're not given decode, it means we're going to be dealing with binary sequence here, and substitution will fail. An error occurs when I use the [M]erge command without this fix.

P.s It's important to merge this before release so we don't introduce the regression