### PR TITLE
Mark the whole line containing 'HEAD' as headline

### DIFF
--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -54,6 +54,8 @@ contexts:
           scope: punctuation.separator.other.git-savvy
         - match: '->'
           scope: punctuation.separator.key-value.branch.git-savvy
+        - match: HEAD
+          scope: constant.other.git.head.git-savvy
         - match: ([^ ,)]+)
           scope: constant.other.git.branch.git-savvy
 

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -7,6 +7,16 @@ hidden: true
 scope: git-savvy.graph
 contexts:
   main:
+    - match: (?=.*\(HEAD )
+      push:
+        - meta_scope: meta.graph.graph-line.head.git-savvy
+        - include: content
+        - match: $
+          pop: true
+
+    - include: content
+
+  content:
     - match: '([| \\/_.-]+)'
       comment: graph lines
       scope: punctuation.other.git-savvy.graph.graph-line
@@ -17,15 +27,6 @@ contexts:
     - match: \s*([0-9a-f]{6,40})\b
       comment: SHA
       scope: constant.numeric.graph.commit-hash.git-savvy
-
-    - match: (?=\s*\(HEAD)
-      push:
-        - meta_scope: meta.graph.graph-line.head.git-savvy
-        - include: branch-name
-        - match: (?=\S)
-          push: message
-        - match: $
-          pop: true
 
     - include: branch-name
 

--- a/syntax/graph.sublime-syntax
+++ b/syntax/graph.sublime-syntax
@@ -5,9 +5,11 @@ name: GitSavvy Graph
 file_extensions: []
 hidden: true
 scope: git-savvy.graph
+variables:
+  sha: '[0-9a-f]{6,40}'
 contexts:
   main:
-    - match: (?=.*\(HEAD )
+    - match: (?=^.*{{sha}} +\(HEAD( ->|\)))
       push:
         - meta_scope: meta.graph.graph-line.head.git-savvy
         - include: content
@@ -24,7 +26,7 @@ contexts:
     - match: '[*●]'
       scope: keyword.graph.commit.git-savvy
 
-    - match: \s*([0-9a-f]{6,40})\b
+    - match: \s*({{sha}})\b
       comment: SHA
       scope: constant.numeric.graph.commit-hash.git-savvy
 

--- a/syntax/test/syntax_test_graph.txt
+++ b/syntax/test/syntax_test_graph.txt
@@ -2,7 +2,7 @@
 * 2b17192 (HEAD -> develop, origin/master, origin/HEAD, master) replace all references to .tmLanguage to .sublime-syntax
 # <-  keyword.graph.commit
 #  ^ constant.numeric.graph.commit-hash
-#           ^ constant.other.git.branch
+#          ^^^^ constant.other.git.head
 #                     ^ constant.other.git.branch
 #               ^ punctuation.separator.key-value.branch
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.branch.git-savvy
@@ -12,6 +12,7 @@
 * f483ab7 (HEAD) update blame syntax format
 # <- meta.graph.graph-line.head.git-savvy
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.graph-line.head.git-savvy
+#          ^^^^ constant.other.git.head
 * 6929182 update (HEAD) make_commit syntax format
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ git-savvy.graph meta.graph.message.git-savvy
 * ede734e update diff syntax format

--- a/syntax/test/syntax_test_graph.txt
+++ b/syntax/test/syntax_test_graph.txt
@@ -9,8 +9,11 @@
 #                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.graph.message.git-savvy
 # <- meta.graph.graph-line.head.git-savvy
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.graph-line.head.git-savvy
-* f483ab7 update blame syntax format
-* 6929182 update make_commit syntax format
+* f483ab7 (HEAD) update blame syntax format
+# <- meta.graph.graph-line.head.git-savvy
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.graph-line.head.git-savvy
+* 6929182 update (HEAD) make_commit syntax format
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ git-savvy.graph meta.graph.message.git-savvy
 * ede734e update diff syntax format
 # <- keyword.graph.commit
 #  ^ constant.numeric.graph.commit-hash

--- a/syntax/test/syntax_test_graph.txt
+++ b/syntax/test/syntax_test_graph.txt
@@ -7,7 +7,8 @@
 #               ^ punctuation.separator.key-value.branch
 #         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.branch.git-savvy
 #                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.graph.message.git-savvy
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.graph-line.head.git-savvy
+# <- meta.graph.graph-line.head.git-savvy
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.graph.graph-line.head.git-savvy
 * f483ab7 update blame syntax format
 * 6929182 update make_commit syntax format
 * ede734e update diff syntax format


### PR DESCRIPTION
Improves #1051

- Mark the whole line so that we can style the dot

![image](https://user-images.githubusercontent.com/8558/50316051-5d27ec80-04b5-11e9-91bb-14439500b26e.png)

- Fixup regex for detached heads
- Really mark the literal 'HEAD' 

![image](https://user-images.githubusercontent.com/8558/50336353-46fa4a80-050e-11e9-8fd0-9fb526e268df.png)
