### PR TITLE
Refresh graph view after checkout

### DIFF
--- a/common/util/view.py
+++ b/common/util/view.py
@@ -82,6 +82,9 @@ def refresh_gitsavvy_interfaces(window,
         if view.settings().get("git_savvy.interface") is not None:
             view.run_command("gs_interface_refresh", {"nuke_cursors": interface_reset_cursor})
 
+        if view.settings().get("git_savvy.log_graph_view", False):
+            view.run_command("gs_log_graph_refresh")
+
 
 def refresh_gitsavvy(view, refresh_sidebar=False, refresh_status_bar=True,
                      interface_reset_cursor=False):


### PR DESCRIPTION
Now, `log_graph_view` is basically a irregular 'interface' so it should be here. Note that `refresh_gitsavvy_interfaces` is only called after checkouts, otherwise the similar `refresh_gitsavvy` is used. 

That doesn't seem correct, and a picky differentiation. We *should* always call `refresh_gitsavvy_interfaces`, but rename it to `refresh_gitsavvy`.