### PR TITLE
Implement Undo for diff-view

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -54,6 +54,15 @@
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },
+    {
+        "keys": ["ctrl+z"],
+        "command": "gs_diff_undo",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
 
     //////////////////
     // STAGE_DIFF VIEW //

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -54,6 +54,15 @@
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },
+    {
+        "keys": ["super+z"],
+        "command": "gs_diff_undo",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
 
     //////////////////
     // STAGE_DIFF VIEW //

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -54,6 +54,15 @@
             { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
         ]
     },
+    {
+        "keys": ["ctrl+z"],
+        "command": "gs_diff_undo",
+        "context": [
+            { "key": "setting.command_mode", "operator": "equal", "operand": false },
+            { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true },
+            { "key": "setting.git_savvy.diff_view.disable_stage", "operator": "equal", "operand": false }
+        ]
+    },
 
     //////////////////
     // STAGE_DIFF VIEW //

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -607,8 +607,7 @@
     },
     {
         "keys": ["tab"],
-        "command": "gs_diff_toggle_setting",
-        "args": { "setting": "in_cached_mode" },
+        "command": "gs_diff_toggle_cached_mode",
         "context": [
             { "key": "setting.command_mode", "operator": "equal", "operand": false },
             { "key": "setting.git_savvy.diff_view", "operator": "equal", "operand": true }

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -299,9 +299,7 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
                 stdin=hunk_diff
             )
 
-        sublime.set_timeout_async(
-            lambda: self.view.run_command("gs_diff_refresh", {'navigate_to_next_hunk': True})
-        )
+        sublime.set_timeout_async(lambda: self.view.run_command("gs_diff_refresh"))
 
     def get_hunk_diff(self, pt):
         """

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -235,11 +235,10 @@ class GsDiffToggleCachedMode(TextCommand):
 
         self.view.run_command("gs_diff_refresh")
 
-        if self.view.settings().get("git_savvy.diff_view.just_hunked"):
-            self.view.settings().set("git_savvy.diff_view.just_hunked", False)
-            history = self.view.settings().get("git_savvy.diff_view.history")
-            _, stdin, _ = history[-1]
-            match = re.search(r'\n(@@ .+)\n', stdin)
+        just_hunked = self.view.settings().get("git_savvy.diff_view.just_hunked")
+        if just_hunked:
+            self.view.settings().set("git_savvy.diff_view.just_hunked", "")
+            match = re.search(r'\n(@@ .+)\n', just_hunked)
             if match is not None:
                 expected_content = match.group(1)
                 region = self.view.find(expected_content, 0, sublime.LITERAL)
@@ -343,7 +342,7 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
             history = self.view.settings().get("git_savvy.diff_view.history") or []
             history.append((args, hunk_diff, pt))
             self.view.settings().set("git_savvy.diff_view.history", history)
-            self.view.settings().set("git_savvy.diff_view.just_hunked", True)
+            self.view.settings().set("git_savvy.diff_view.just_hunked", hunk_diff)
 
         sublime.set_timeout_async(lambda: self.view.run_command("gs_diff_refresh"))
 
@@ -469,6 +468,7 @@ class GsDiffUndo(TextCommand, GitCommand):
 
         self.git(*args, stdin=stdin)
         self.view.settings().set("git_savvy.diff_view.history", history)
+        self.view.settings().set("git_savvy.diff_view.just_hunked", stdin)
 
         self.view.run_command("gs_diff_refresh")
         self.view.sel().clear()

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -3,6 +3,7 @@ Implements a special view to visualize and stage pieces of a project's
 current diff.
 """
 
+from contextlib import contextmanager
 import os
 import re
 import bisect
@@ -255,9 +256,24 @@ class GsDiffToggleCachedMode(TextCommand):
             sel.clear()
             for (a, b) in last_cursors:
                 sel.add(sublime.Region(a, b))
-            self.view.show(sel)
+
+            # The 'flipping' between the two states should be as fast as possible and
+            # without visual clutter.
+            with no_animations():
+                self.view.show(sel)
         else:
             self.view.run_command("gs_diff_navigate")
+
+
+@contextmanager
+def no_animations():
+    pref = sublime.load_settings("Preferences.sublime-settings")
+    current = pref.get("animation_enabled")
+    pref.set("animation_enabled", False)
+    try:
+        yield
+    finally:
+        pref.set("animation_enabled", current)
 
 
 class GsDiffFocusEventListener(EventListener):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -207,6 +207,7 @@ class GsDiffToggleCachedMode(TextCommand):
     Toggle `in_cached_mode`.
     """
 
+    # NOTE: MUST NOT be async, otherwise `view.show` will not update the view 100%!
     def run(self, edit):
         setting = 'in_cached_mode'
 
@@ -453,10 +454,8 @@ class GsDiffUndo(TextCommand, GitCommand):
     Undo the last action taken in the diff view, if possible.
     """
 
+    # NOTE: MUST NOT be async, otherwise `view.show` will not update the view 100%!
     def run(self, edit):
-        sublime.set_timeout_async(self.run_async)
-
-    def run_async(self):
         history = self.view.settings().get("git_savvy.diff_view.history") or []
         if not history:
             window = self.view.window()

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -241,7 +241,11 @@ class GsDiffToggleCachedMode(TextCommand):
         self.view.run_command("gs_diff_refresh")
 
         just_hunked = self.view.settings().get("git_savvy.diff_view.just_hunked")
-        if just_hunked:
+        # Check for `last_cursors` as well bc it is only falsy on the *first*
+        # switch. T.i. if the user hunked and then switches to see what will be
+        # actually comitted, the view starts at the top. Later, the view will
+        # show the last added hunk.
+        if just_hunked and last_cursors:
             self.view.settings().set("git_savvy.diff_view.just_hunked", "")
             region = find_hunk_in_view(self.view, just_hunked)
             if region:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -63,6 +63,8 @@ class GsDiffCommand(WindowCommand, GitCommand):
             settings.set("git_savvy.diff_view.target_commit", target_commit)
             settings.set("git_savvy.diff_view.show_diffstat", self.savvy_settings.get("show_diffstat", True))
             settings.set("git_savvy.diff_view.disable_stage", disable_stage)
+            settings.set("git_savvy.diff_view.history", [])
+            settings.set("git_savvy.diff_view.just_hunked", "")
 
             # Clickable lines:
             # (A)  common/commands/view_manipulation.py  |   1 +
@@ -339,7 +341,7 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
                 stdin=hunk_diff
             )
 
-            history = self.view.settings().get("git_savvy.diff_view.history") or []
+            history = self.view.settings().get("git_savvy.diff_view.history")
             history.append((args, hunk_diff, pt, in_cached_mode))
             self.view.settings().set("git_savvy.diff_view.history", history)
             self.view.settings().set("git_savvy.diff_view.just_hunked", hunk_diff)
@@ -455,7 +457,7 @@ class GsDiffUndo(TextCommand, GitCommand):
 
     # NOTE: MUST NOT be async, otherwise `view.show` will not update the view 100%!
     def run(self, edit):
-        history = self.view.settings().get("git_savvy.diff_view.history") or []
+        history = self.view.settings().get("git_savvy.diff_view.history")
         if not history:
             window = self.view.window()
             if window:

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -376,7 +376,8 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
             # immediately following diff headers.
             (set(self.hunk_starts) - set(self.header_ends)) |
             # The last hunk ends at the end of the file.
-            set((self.view.size(), ))
+            # It should include the last line (`+ 1`).
+            set((self.view.size() + 1, ))
         ))
 
         sublime.set_timeout_async(lambda: self.apply_diffs_for_pts(cursor_pts, reset), 0)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -225,8 +225,7 @@ class GsDiffToggleCachedMode(TextCommand):
         settings = self.view.settings()
 
         last_cursors = settings.get('git_savvy.diff_view.last_cursors') or []
-        cursors = [(s.a, s.b) for s in self.view.sel()]
-        settings.set('git_savvy.diff_view.last_cursors', cursors)
+        settings.set('git_savvy.diff_view.last_cursors', pickle_sel(self.view.sel()))
 
         setting_str = "git_savvy.diff_view.{}".format(setting)
         current_mode = settings.get(setting_str)
@@ -253,10 +252,18 @@ class GsDiffToggleCachedMode(TextCommand):
             # The 'flipping' between the two states should be as fast as possible and
             # without visual clutter.
             with no_animations():
-                set_and_show_cursor(self.view, [sublime.Region(a, b) for a, b in last_cursors])
+                set_and_show_cursor(self.view, unpickle_sel(last_cursors))
 
         else:
             self.view.run_command("gs_diff_navigate")
+
+
+def pickle_sel(sel):
+    return [(s.a, s.b) for s in sel]
+
+
+def unpickle_sel(pickled_sel):
+    return [sublime.Region(a, b) for a, b in pickled_sel]
 
 
 def set_and_show_cursor(view, cursors):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -319,10 +319,10 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
                 stdin=hunk_diff
             )
 
-        history = self.view.settings().get("git_savvy.diff_view.history") or []
-        history.append((args, hunk_diff, cursor_pts[0]))
-        self.view.settings().set("git_savvy.diff_view.history", history)
-        self.view.settings().set("git_savvy.diff_view.just_hunked", True)
+            history = self.view.settings().get("git_savvy.diff_view.history") or []
+            history.append((args, hunk_diff, pt))
+            self.view.settings().set("git_savvy.diff_view.history", history)
+            self.view.settings().set("git_savvy.diff_view.just_hunked", True)
 
         sublime.set_timeout_async(lambda: self.view.run_command("gs_diff_refresh"))
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -340,7 +340,7 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
             )
 
             history = self.view.settings().get("git_savvy.diff_view.history") or []
-            history.append((args, hunk_diff, pt))
+            history.append((args, hunk_diff, pt, in_cached_mode))
             self.view.settings().set("git_savvy.diff_view.history", history)
             self.view.settings().set("git_savvy.diff_view.just_hunked", hunk_diff)
 
@@ -462,7 +462,7 @@ class GsDiffUndo(TextCommand, GitCommand):
                 window.status_message("Undo stack is empty")
             return
 
-        args, stdin, cursor = history.pop()
+        args, stdin, cursor, in_cached_mode = history.pop()
         # Toggle the `--reverse` flag.
         args[1] = "-R" if not args[1] else None
 
@@ -471,6 +471,9 @@ class GsDiffUndo(TextCommand, GitCommand):
         self.view.settings().set("git_savvy.diff_view.just_hunked", stdin)
 
         self.view.run_command("gs_diff_refresh")
-        self.view.sel().clear()
-        self.view.sel().add(cursor)
-        self.view.show(cursor)
+
+        # The cursor is only applicable if we're still in the same cache/stage mode
+        if self.view.settings().get("git_savvy.diff_view.in_cached_mode") == in_cached_mode:
+            self.view.sel().clear()
+            self.view.sel().add(cursor)
+            self.view.show(cursor)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -240,13 +240,10 @@ class GsDiffToggleCachedMode(TextCommand):
         just_hunked = self.view.settings().get("git_savvy.diff_view.just_hunked")
         if just_hunked:
             self.view.settings().set("git_savvy.diff_view.just_hunked", "")
-            match = re.search(r'\n(@@ .+)\n', just_hunked)
-            if match is not None:
-                expected_content = match.group(1)
-                region = self.view.find(expected_content, 0, sublime.LITERAL)
-                if region:
-                    set_and_show_cursor(self.view, region.a)
-                    return
+            region = find_hunk_in_view(self.view, just_hunked)
+            if region:
+                set_and_show_cursor(self.view, region.a)
+                return
 
         if last_cursors:
             # The 'flipping' between the two states should be as fast as possible and
@@ -256,6 +253,15 @@ class GsDiffToggleCachedMode(TextCommand):
 
         else:
             self.view.run_command("gs_diff_navigate")
+
+
+def find_hunk_in_view(view, hunk):
+    match = re.search(r'\n(@@ .+)\n', hunk)
+    if match is not None:
+        expected_content = match.group(1)
+        region = view.find(expected_content, 0, sublime.LITERAL)
+        if region:
+            return region
 
 
 def pickle_sel(sel):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -270,7 +270,7 @@ def find_hunk_in_view(view, hunk):
 
 def extract_first_hunk(hunk):
     hunk_lines = hunk.split('\n')
-    not_hunk_start = lambda l: not l.startswith('@@ ')  # noqa: E731
+    not_hunk_start = lambda l: not l.startswith('@@ ')
 
     try:
         start, *rest = dropwhile(not_hunk_start, hunk_lines)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -303,7 +303,7 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
             )
 
         history = self.view.settings().get("git_savvy.diff_view.history") or []
-        history.append((args, hunk_diff))
+        history.append((args, hunk_diff, cursor_pts[0]))
         self.view.settings().set("git_savvy.diff_view.history", history)
 
         sublime.set_timeout_async(lambda: self.view.run_command("gs_diff_refresh"))
@@ -426,7 +426,7 @@ class GsDiffUndo(TextCommand, GitCommand):
                 window.status_message("Undo stack is empty")
             return
 
-        args, stdin = history.pop()
+        args, stdin, cursor = history.pop()
         # Toggle the `--reverse` flag.
         args[1] = "-R" if not args[1] else None
 
@@ -434,3 +434,6 @@ class GsDiffUndo(TextCommand, GitCommand):
         self.view.settings().set("git_savvy.diff_view.history", history)
 
         self.view.run_command("gs_diff_refresh")
+        self.view.sel().clear()
+        self.view.sel().add(cursor)
+        self.view.show(cursor)

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -107,7 +107,6 @@ class GsDiffCommand(WindowCommand, GitCommand):
             diff_views[view_key] = diff_view
 
         self.window.focus_view(diff_view)
-        diff_view.sel().clear()
         diff_view.run_command("gs_diff_refresh")
         diff_view.run_command("gs_handle_vintageous")
 

--- a/popups/diff_view.html
+++ b/popups/diff_view.html
@@ -26,6 +26,7 @@
 <h3>Other</h3>
 <ul>
   <li><code><span class="shortcut-key">?&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>show this help popup</code></li>
+  <li><code><span class="shortcut-key">{super_key}-z&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>undo last action</code></li>
 </ul>
 
 <h3>Vintageous friendly mode</h3>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pycodestyle]
 count = False
-ignore = E401, W503, W504
+ignore = E401, E731, W503, W504
 max-line-length = 120
 exclude =
   tests/mockito,
@@ -11,6 +11,7 @@ exclude =
 max-line-length = 120
 ignore =
     E401,
+    E731,
     D,
     W503,
     W504

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -4,8 +4,10 @@ import re
 import sublime
 
 from unittesting import DeferrableTestCase
-from GitSavvy.tests.mockito import expect, unstub, when, spy2
+from GitSavvy.tests.mockito import when, unstub
+from GitSavvy.tests.parameterized import parameterized as p
 
+import GitSavvy.core.commands.diff as module
 from GitSavvy.core.commands.diff import GsDiffCommand, GsDiffRefreshCommand
 
 
@@ -17,27 +19,216 @@ def fixture(name):
         return f.read()
 
 
-class TestDiffView(DeferrableTestCase):
-    def setUp(self):
-        original_window_id = sublime.active_window().id()
+class TestDiffViewInternalFunctions(DeferrableTestCase):
+    @classmethod
+    def setUpClass(cls):
         sublime.run_command("new_window")
-
-        yield lambda: sublime.active_window().id() != original_window_id
-
-        self.window = sublime.active_window()
-        self.view = sublime.active_window().new_file()
-        self.window.focus_view(self.view)
-        yield lambda: sublime.active_window().active_view().id() == self.view.id()
-        # make sure we have a window to work with
+        cls.window = sublime.active_window()
         s = sublime.load_settings("Preferences.sublime-settings")
         s.set("close_windows_when_empty", False)
+
+    @classmethod
+    def tearDownClass(self):
+        self.window.run_command('close_window')
+
+    @p.expand([
+        ([1, 2, 3, 4, 5], [[1, 2, 3, 4, 5], [2, 3, 4], [3]]),
+        ([1, 2, 3, 4], [[1, 2, 3, 4], [2, 3]]),
+        ([1, 2, 3], [[1, 2, 3], [2]]),
+        ([1, 2], [[1, 2]]),
+        ([1], [[1]]),
+        ([], [])
+    ])
+    def test_shrink_list(self, IN, expected):
+        actual = module.shrink_list_sym(IN)
+        actual = list(actual)
+        self.assertEqual(actual, expected)
+
+    @p.expand([
+        (26, [(20, 24), (15, 19), (10, 14), (5, 9), (0, 4)]),
+        (25, [(20, 24), (15, 19), (10, 14), (5, 9), (0, 4)]),
+
+        (24, [(15, 19), (10, 14), (5, 9), (0, 4)]),
+        (23, [(15, 19), (10, 14), (5, 9), (0, 4)]),
+        (22, [(15, 19), (10, 14), (5, 9), (0, 4)]),
+        (21, [(15, 19), (10, 14), (5, 9), (0, 4)]),
+        (20, [(15, 19), (10, 14), (5, 9), (0, 4)]),
+
+        (19, [(10, 14), (5, 9), (0, 4)]),
+        (18, [(10, 14), (5, 9), (0, 4)]),
+        (17, [(10, 14), (5, 9), (0, 4)]),
+        (16, [(10, 14), (5, 9), (0, 4)]),
+        (15, [(10, 14), (5, 9), (0, 4)]),
+
+        (14, [(5, 9), (0, 4)]),
+        (13, [(5, 9), (0, 4)]),
+        (12, [(5, 9), (0, 4)]),
+        (11, [(5, 9), (0, 4)]),
+        (10, [(5, 9), (0, 4)]),
+
+        (9, [(0, 4)]),
+        (8, [(0, 4)]),
+        (7, [(0, 4)]),
+        (6, [(0, 4)]),
+        (5, [(0, 4)]),
+
+        (4, []),
+        (3, []),
+        (2, []),
+        (1, []),
+        (0, []),
+
+        (-1, []),
+    ])
+    def test_line_ranges_before_point(self, IN, expected):
+        # ATT: All '0123' actually are '0123\n' (length: 5)
+        VIEW_CONTENT = """\
+0123
+0123
+0123
+0123
+0123
+"""
+        view = self.window.new_file()
+        self.addCleanup(view.close)
+        view.run_command('append', {'characters': VIEW_CONTENT})
+        view.set_scratch(True)
+
+        actual = module.line_regions_before_pt(view, IN)
+        # unpack `sublime.Region`s
+        actual = module.pickle_sel(actual)
+
+        self.assertEqual(actual, expected)
+
+    @p.expand([
+        (0, None),
+        (1, None),
+        (2, None),
+        (3, None),
+        (4, None),
+
+        (10, (5, 9)),
+        (11, (5, 9)),
+        (12, (5, 9)),
+        (13, (5, 9)),
+        (14, (5, 9)),
+        (15, (5, 9)),
+        (16, (5, 9)),
+        (17, (5, 9)),
+        (18, (5, 9)),
+        (19, (5, 9)),
+
+        (25, (20, 24)),
+        (26, (20, 24)),
+        (27, (20, 24)),
+        (28, (20, 24)),
+        (29, (20, 24)),
+        (30, (20, 24)),
+        (31, (20, 24)),
+        (32, (20, 24)),
+        (33, (20, 24)),
+        (34, (20, 24)),
+        (35, (20, 24)),
+
+    ])
+    def test_first_hunk_start_before_pt(self, IN, expected):
+        VIEW_CONTENT = """\
+0123
+@@ 1
+1123
+1123
+@@ 2
+2123
+2123
+"""
+
+        view = self.window.new_file()
+        self.addCleanup(view.close)
+        view.run_command('append', {'characters': VIEW_CONTENT})
+        view.set_scratch(True)
+
+        actual = module.first_hunk_start_before_pt(view, IN)
+        actual = (actual.a, actual.b) if actual else actual
+        self.assertEqual(actual, expected)
+
+    @p.expand([
+        ("@@ 1\n1234\n1567\n1890", (30, 34)),
+        ("@@ 1\n1234\n1567", (30, 34)),
+        ("@@ 1\n1567\n1890", (30, 34)),
+        ("@@ 1\n1234", (30, 34)),
+        ("@@ 1\n1567", (30, 34)),
+        ("@@ 1\n1890", (30, 34)),
+
+        ("@@ 1\n1XXX\n1XXX", (30, 34)),
+
+        ("@@ X\n1234\n1567\n1890", (30, 34)),
+        ("@@ X\n1567\n1890", (30, 34)),
+        ("@@ X\n1234\n1567", (30, 34)),
+        ("@@ X\n1234", (30, 34)),
+        ("@@ X\n1567", (30, 34)),
+        ("@@ X\n1890", (30, 34)),
+        ("@@ X\n1XXX\n1567\n1890", (30, 34)),
+        ("@@ X\n1234\n1567\n1XXX", (30, 34)),
+        ("@@ X\n1XXX\n1567\n1XXX", (30, 34)),
+
+        ("@@ X\n1234\n1XXX\n1XXX", None),
+        ("@@ X\n1XXX\n1XXX\n1890", None),
+        ("@@ X\n1XXX\n1XXX\n1XXX", None),
+        ("@@ X\n0123", None),
+
+        # Only consider first hunk in input
+        ("@@ X\n1234\n1567\n1890\n@@ 2\n2345\n2678", (30, 34)),
+        ("@@ X\n1234\n@@ 2\n2345\n2678", (30, 34)),
+        ("@@ X\n1234\n1567\n1890\n@@ X\n2XXX\n2678", (30, 34)),
+
+        # Ensure invalid input doesn't throw
+        ("@@ X", None),
+        ("@@ X\n", None),
+        ("1234\n1567\n1890", None),
+    ])
+    def test_find_hunk_in_view(self, IN, expected):
+        VIEW_CONTENT = """\
+0123
+diff --git a/barz b/fooz
+@@ 1
+1234
+1567
+1890
+@@ 2
+2345
+2678
+"""
+
+        view = self.window.new_file()
+        self.addCleanup(view.close)
+        view.run_command('append', {'characters': VIEW_CONTENT})
+        view.set_scratch(True)
+
+        actual = module.find_hunk_in_view(view, IN)
+        actual = (actual.a, actual.b) if actual else actual
+        self.assertEqual(actual, expected)
+
+
+class TestDiffView(DeferrableTestCase):
+    @classmethod
+    def setUpClass(cls):
+        sublime.run_command("new_window")
+        cls.window = sublime.active_window()
+        s = sublime.load_settings("Preferences.sublime-settings")
+        s.set("close_windows_when_empty", False)
+
+    @classmethod
+    def tearDownClass(self):
+        self.window.run_command('close_window')
+
+    def setUp(self):
+        self.view = self.window.new_file()
 
     def tearDown(self):
         if self.view:
             self.view.set_scratch(True)
-            self.view.window().focus_view(self.view)
             self.view.close()
-        self.window.run_command('close_window')
+
         unstub()
 
     def test_extract_clickable_lines(self):

--- a/unittesting.json
+++ b/unittesting.json
@@ -1,4 +1,5 @@
 {
     "deferred": true,
-    "capture_console": true
+    "capture_console": true,
+    "legacy_runner": false
 }


### PR DESCRIPTION
Fixes #1036
Fixes #1074 

Bugs/Observations: 

- [ ] ~~can't double click into a new file ('@@ -16,7 +16 @@ ...')~~ Now in #1091 
- [x] just checking the hunk start ('@@ ...') for a good jump position isn't good enough. This line is just not stable enough. I will instead search for the actual hunk content.
- [x] cursor can still stay in meaningless land if the diff was actually empty before
- [x] cursor can land at eof which does not count as hunk so the user can't [h]unk it
- [ ] jump to file from hunk is not 100% implemented
- [ ] hunking with multiple cursor is cheaply implemented. If you have two cursors in the same hunk it throws (of course 🙄), otherwise it calls git n times.
- [ ] [H]unk complete file, or from this hunk to end of file functionality is clearly missing
- [ ] Also: [D]iscard complete file
- [ ] Maybe: Navigate to next/previous [f]ile
- [ ] If you staged, and then [c]ommit the commit view closes, and the diff view gains focus. It should probably close as well iff there is nothing left to stage
- [ ] ~~Prelude A..B shows target..base instead of base..target~~ Now in #1090 
- [ ] Ensure cursor stays in hunk position after hunking last hunk of a file and then therefore going to the next hunk in the next file is required
- [ ] Collapse multiple cursors to one after hunking
- [ ] Allow fast opening of `gs_diff`'s for current file (e.g. from the status file) which is broken right now