### PR TITLE
Do not imperatively refresh ui after Log actions

### DIFF
--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -176,11 +176,9 @@ class GsLogActionCommand(PanelActionMixin, WindowCommand, GitCommand):
 
     def checkout_commit(self):
         self.checkout_ref(self._commit_hash)
-        util.view.refresh_gitsavvy(self.view, refresh_sidebar=True)
 
     def cherry_pick(self):
         self.git("cherry-pick", self._commit_hash)
-        util.view.refresh_gitsavvy(self.view, refresh_sidebar=True)
 
     def revert_commit(self):
         self.window.run_command("gs_revert_commit", {
@@ -224,4 +222,3 @@ class GsLogActionCommand(PanelActionMixin, WindowCommand, GitCommand):
 
     def checkout_file_at_commit(self):
         self.checkout_ref(self._commit_hash, fpath=self._file_path)
-        util.view.refresh_gitsavvy(self.view, refresh_sidebar=True)


### PR DESCRIPTION
The three calls herein used `self.view` which is not defined since
`GsLogActionCommand` is a `WindowCommand`. So basically all commands raised
and did nothing.

I think doing nothing is the correct approach here since after closing the
panel, `on_activated` callbacks run for all important views anyway.

To actually refresh _other_ visible views beside the active one would be a
useful feature though.

