### PR TITLE
Faster responses after discarding or ignoring files from status dashboard

### DIFF
--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -571,8 +571,8 @@ class GsStatusDiscardChangesToFileCommand(TextCommand, GitCommand):
         interface = ui.get_interface(self.view.id())
         self.discard_untracked(interface)
         self.discard_unstaged(interface)
-        util.view.refresh_gitsavvy(self.view)
         self.view.window().status_message("Successfully discarded changes.")
+        interface.refresh_repo_status_and_render()
 
     def discard_untracked(self, interface):
         valid_ranges = interface.get_view_regions("untracked_files")
@@ -678,7 +678,8 @@ class GsStatusDiscardAllChangesCommand(TextCommand, GitCommand):
                                           "and delete all untracked files")
     def run(self, edit):
         self.discard_all_unstaged()
-        util.view.refresh_gitsavvy(self.view)
+        interface = ui.get_interface(self.view.id())
+        interface.refresh_repo_status_and_render()
 
 
 class GsStatusCommitCommand(TextCommand, GitCommand):

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -743,7 +743,7 @@ class GsStatusIgnoreFileCommand(TextCommand, GitCommand):
             for fpath in file_paths:
                 self.add_ignore(os.path.join("/", fpath))
             self.view.window().status_message("Successfully ignored files.")
-            util.view.refresh_gitsavvy(self.view)
+            interface.refresh_repo_status_and_render()
 
 
 class GsStatusIgnorePatternCommand(TextCommand, GitCommand):


### PR DESCRIPTION
The bug basically is that you could not hit `ddd` in a meaningful fast way to discard three files in a row.