### PR TITLE
Add support for "env" settings and GIT_OPTIONAL_LOCKS

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -23,6 +23,13 @@
     "git_path": "",
 
     /*
+        Set custom environment variables for git command execution.
+    */
+    "env": {
+        "GIT_OPTIONAL_LOCKS": "0"
+    },
+
+    /*
         Change this to `true` when doing dev work on GitSavvy.
      */
     "dev_mode": false,

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -26,7 +26,6 @@
         Set custom environment variables for git command execution.
     */
     "env": {
-        "GIT_OPTIONAL_LOCKS": "0"
     },
 
     /*

--- a/core/git_command.py
+++ b/core/git_command.py
@@ -187,6 +187,9 @@ class GitCommand(StatusMixin,
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
             environ = os.environ.copy()
+            savvy_env = self.savvy_settings.get("env")
+            if savvy_env:
+                environ.update(savvy_env)
             environ.update(custom_environ or {})
             start = time.time()
             p = subprocess.Popen(command,

--- a/core/git_mixins/status.py
+++ b/core/git_mixins/status.py
@@ -20,7 +20,8 @@ IndexedEntry.__new__.__defaults__ = (None, ) * 8
 class StatusMixin():
 
     def _get_status(self):
-        return self.git("status", "--porcelain", "-z", "-b").rstrip("\x00").split("\x00")
+        return self.git("status", "--porcelain", "-z", "-b",
+                        custom_environ={"GIT_OPTIONAL_LOCKS": "0"}).rstrip("\x00").split("\x00")
 
     def _parse_status_for_file_statuses(self, lines):
         porcelain_entries = lines[1:].__iter__()


### PR DESCRIPTION
Git 2.17+ supports the custom environment variable "GIT_OPTIONAL_LOCKS"
which can be set by editors to ask git to reduce the number of file
locks when querying for status information such as "git status". This
helps to speed up some commands and helps improving concurrent status
queries.

This commit therefore introduces the "env" setting in the 
GitSavvy.sublime-setting, which is injected into the "environ" object
before calling a git command.

The "env" setting contains the "GIT_OPTIONAL LOCKS: 0" by default.
A user can override this setting or add other custom environment
variables.

Note:

Newer versions of git also support a command line argument to disable
optional locks. But using it would cause backward compatibility issues
if a user still works with a git version, which does not support it.

Hotfixes should be submitted to `master` branch. As part of the PR process,
you will be asked to provide the information necessary to make that happen.

Pull requests on new features should be submitted to `dev` branch and will be
regularly merged into `master` after evaluations over an extended period of
time.
