### PR TITLE
Fix diff view syntax settings

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -178,6 +178,17 @@
         "keys": ["ctrl+,"],
         "command": "edit_settings",
         "args": {
+            "base_file": "${packages}/GitSavvy/syntax/diff_view.sublime-settings",
+            "default": "// Override settings for diff syntax-specific.\n{\n\t$0\n}\n"
+        },
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.diff_view" }
+        ]
+    },
+    {
+        "keys": ["ctrl+,"],
+        "command": "edit_settings",
+        "args": {
             "base_file": "${packages}/GitSavvy/syntax/graph.sublime-settings",
             "default": "// Override settings for graph syntax-specific.\n{\n\t$0\n}\n"
         },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -178,6 +178,17 @@
         "keys": ["super+,"],
         "command": "edit_settings",
         "args": {
+            "base_file": "${packages}/GitSavvy/syntax/diff_view.sublime-settings",
+            "default": "// Override settings for diff syntax-specific.\n{\n\t$0\n}\n"
+        },
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.diff_view" }
+        ]
+    },
+    {
+        "keys": ["super+,"],
+        "command": "edit_settings",
+        "args": {
             "base_file": "${packages}/GitSavvy/syntax/graph.sublime-settings",
             "default": "// Override settings for graph syntax-specific.\n{\n\t$0\n}\n"
         },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -178,6 +178,17 @@
         "keys": ["ctrl+,"],
         "command": "edit_settings",
         "args": {
+            "base_file": "${packages}/GitSavvy/syntax/diff_view.sublime-settings",
+            "default": "// Override settings for diff syntax-specific.\n{\n\t$0\n}\n"
+        },
+        "context": [
+            { "key": "selector", "operator": "equal", "operand": "git-savvy.diff_view" }
+        ]
+    },
+    {
+        "keys": ["ctrl+,"],
+        "command": "edit_settings",
+        "args": {
             "base_file": "${packages}/GitSavvy/syntax/graph.sublime-settings",
             "default": "// Override settings for graph syntax-specific.\n{\n\t$0\n}\n"
         },

--- a/syntax/diff_view.sublime-settings
+++ b/syntax/diff_view.sublime-settings
@@ -1,0 +1,16 @@
+{
+    // same on all syntaxes
+    "auto_indent": false,
+    "detect_indentation": false,
+    "draw_indent_guides": false,
+    "draw_white_space": "None",
+    "gutter": false,
+    "line_numbers": false,
+    "margin": 20,
+    "rulers": [],
+    "translate_tabs_to_spaces": false,
+    "word_wrap": false,
+    // syntax specific
+    "match_brackets": false,
+    "match_tags": false
+}


### PR DESCRIPTION
Bc of the new prelude in the diff view, we at some point had to introduce a new syntax for it. But we forgot to add the typical syntax settings, and the edit settings shortcut.

This PR adds them.