### PR TITLE
Fix clickable hunk header when it doesn't contain a line count

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -93,7 +93,7 @@ class GsDiffCommand(WindowCommand, GitCommand):
             # Clickable line:
             # @@ -69,6 +69,7 @@ class GsHandleVintageousCommand(TextCommand):
             #           ^^ we want the second (current) line offset of the diff
-            settings.set("result_line_regex", r"^@@ [^+]*\+(\d+),")
+            settings.set("result_line_regex", r"^@@ [^+]*\+(\d+)")
             settings.set("result_base_dir", repo_path)
 
             if not title:

--- a/tests/fixtures/diff_1.txt
+++ b/tests/fixtures/diff_1.txt
@@ -6,7 +6,7 @@ diff --git a/core/commands/custom.py b/core/commands/custom.py
 index 1facb191..8b079d4d 100644
 --- a/core/commands/custom.py
 +++ b/core/commands/custom.py
-@@ -16,7 +16,7 @@ class CustomCommandThread(threading.Thread):
+@@ -16 +16 @@ class CustomCommandThread(threading.Thread):
          self.daemon = True
  
      def run(self):

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -42,7 +42,6 @@ class TestDiffView(DeferrableTestCase):
 
     def test_extract_clickable_lines(self):
         REPO_PATH = '/not/there'
-        FILE_PATH = '/not/there/README.md'
         DIFF = fixture('diff_1.txt')
 
         when(GsDiffRefreshCommand).git('diff', ...).thenReturn(DIFF)
@@ -64,7 +63,6 @@ class TestDiffView(DeferrableTestCase):
 
     def test_result_file_regex(self):
         REPO_PATH = '/not/there'
-        FILE_PATH = '/not/there/README.md'
         DIFF = fixture('diff_1.txt')
 
         when(GsDiffRefreshCommand).git('diff', ...).thenReturn(DIFF)


### PR DESCRIPTION
As title. In the hunk header both `@@ -16,7 +16,7 @@` and `@@ -16 +16 @@` (without the line count) are allowed so we should support both. 

Extracted from #1075 