### PR TITLE
Tags refactor

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -338,7 +338,7 @@
         "command": "gs_view_git_log"
     },
     {
-        "caption": "git: tag",
+        "caption": "git: tags",
         "command": "gs_show_tags"
     },
     {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -338,7 +338,7 @@
         "command": "gs_view_git_log"
     },
     {
-        "caption": "git: tags",
+        "caption": "git: tag",
         "command": "gs_show_tags"
     },
     {

--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -370,7 +370,7 @@
             status
             branch
             rebase
-            tag
+            tags
             graph
 
      */
@@ -378,7 +378,7 @@
         "status",
         "branch",
         "rebase",
-        "tag",
+        "tags",
         "graph"
     ],
 

--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -12,7 +12,7 @@ class GsTabCycleCommand(TextCommand, GitCommand):
         "status": "gs_show_status",
         "branch": "gs_show_branch",
         "rebase": "gs_show_rebase",
-        "tag": "gs_show_tags",
+        "tags": "gs_show_tags",
         "graph": "gs_log_graph_current_branch"
     }
 
@@ -20,7 +20,7 @@ class GsTabCycleCommand(TextCommand, GitCommand):
         "status": "git_savvy.status_view",
         "branch": "git_savvy.branch_view",
         "rebase": "git_savvy.rebase_view",
-        "tag": "git_savvy.tags_view",
+        "tags": "git_savvy.tags_view",
         "graph": "git_savvy.log_graph_view"
     }
 
@@ -31,7 +31,6 @@ class GsTabCycleCommand(TextCommand, GitCommand):
         to_load = target or self.get_next(source, reverse)
         if not to_load:
             return
-        to_load = "tag" if to_load == "tags" else to_load
         view_signature = self.view_signatures[to_load]
 
         self.view.window().run_command("hide_panel", {"cancel": True})


### PR DESCRIPTION
as discussed in #998, we are going to revert the previous commit which changes `tags` to `tag` but only keeping the user command.