### PR TITLE
Do not provide both `file_path` and `current_file`

### DIFF
--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -198,7 +198,6 @@ class GsLogActionCommand(PanelActionMixin, WindowCommand, GitCommand):
         self.window.run_command("gs_diff", {
             "in_cached_mode": cache,
             "file_path": self._file_path,
-            "current_file": bool(self._file_path),
             "base_commit": self._commit_hash,
             "disable_stage": True
         })

--- a/core/interfaces/status.py
+++ b/core/interfaces/status.py
@@ -495,14 +495,12 @@ class GsStatusDiffCommand(TextCommand, GitCommand):
         for fpath in non_cached_files:
             self.view.window().run_command("gs_diff", {
                 "file_path": fpath,
-                "current_file": True
             })
 
         for fpath in cached_files:
             self.view.window().run_command("gs_diff", {
                 "file_path": fpath,
                 "in_cached_mode": True,
-                "current_file": True
             })
 
 


### PR DESCRIPTION
`current_file` basically takes precedence and fills `file_path` with
the current filename of the active view (using `self.file_path`). This
is not what we want here.

Fixes #1096

