### PR TITLE
Auto-close commit info panel if user moves away

### DIFF
--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -265,16 +265,27 @@ class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):
         actual = panel.find(COMMIT_2, 0, sublime.LITERAL)
         self.assertTrue(actual)
 
-    def _test_afocus_info_panel(self):
+    def test_auto_close_panel_if_user_moves_away(self):
+        view = self.create_new_view(self.window)
         log_view = yield from self.setup_graph_view_async()
 
-        yield 2500
+        self.window.focus_view(view)
 
-    def _test(self):
+        self.assertTrue(self.window.active_panel() is None)
+
+    def test_auto_show_panel_if_log_view_gains_focus_again(self):
+        view = self.create_new_view(self.window)
+        log_view = yield from self.setup_graph_view_async()
+
+        self.window.focus_view(view)
+        self.window.focus_view(log_view)
+
+        self.assertEqual(self.window.active_panel(), 'output.show_commit_info')
+
+    def test_do_not_hide_panel_if_it_gains_focus(self):
+        log_view = yield from self.setup_graph_view_async()
         panel = self.window.find_output_panel('show_commit_info')
 
         self.window.focus_view(panel)
 
-        log_view.run_command('gs_log_graph_navigate')
-        log_view.run_command('gs_log_graph_navigate')
-        yield 2000
+        self.assertEqual(self.window.active_panel(), 'output.show_commit_info')


### PR DESCRIPTION
Automatically hides or shows the commit info panel if the user activates a
different view/buffer. (Except if the panel itself gains focus.)

