### PR TITLE
Fix commit hash extraction for log graph

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -13,7 +13,7 @@ from ..ui_mixins.quick_panel import show_branch_panel
 
 COMMIT_NODE_CHAR = "●"
 COMMIT_NODE_CHAR_OPTIONS = "●*"
-GRAPH_CHAR_OPTIONS = r" /_\|\-."
+GRAPH_CHAR_OPTIONS = r" /_\|\-\\."
 COMMIT_LINE = re.compile(
     "^[{graph_chars}]*[{node_chars}][{graph_chars}]* (?P<commit_hash>[a-f0-9]{{5,40}})".format(
         graph_chars=GRAPH_CHAR_OPTIONS, node_chars=COMMIT_NODE_CHAR_OPTIONS))
@@ -252,15 +252,16 @@ def draw_info_panel_for_line(wid, line_text, show_panel):
     window = sublime.Window(wid)
 
     if show_panel:
-        m = COMMIT_LINE.search(line_text)
-        commit_hash = m.groupdict()['commit_hash'] if m else ""
-        if len(commit_hash) <= 3:
-            return
-
+        commit_hash = extract_commit_hash(line_text)
         window.run_command("gs_show_commit_info", {"commit_hash": commit_hash})
     else:
         if window.active_panel() == "output.show_commit_info":
             window.run_command("hide_panel")
+
+
+def extract_commit_hash(line):
+    match = COMMIT_LINE.search(line)
+    return match.groupdict()['commit_hash'] if match else ""
 
 
 class GsLogGraphToggleMoreInfoCommand(TextCommand, WindowCommand, GitCommand):
@@ -314,8 +315,7 @@ class GsLogGraphActionCommand(GsLogActionCommand):
         lines = util.view.get_lines_from_regions(view, self.selections)
         line = lines[0]
 
-        m = COMMIT_LINE.search(line)
-        self._commit_hash = m.groupdict()['commit_hash'] if m else ""
+        self._commit_hash = extract_commit_hash(line)
         self._file_path = self.file_path
 
         if not len(self.selections) == 1:

--- a/tests/test_graph_view.py
+++ b/tests/test_graph_view.py
@@ -4,12 +4,14 @@ from textwrap import dedent
 import sublime
 
 from unittesting import DeferrableTestCase
+from GitSavvy.tests.parameterized import parameterized as p
 from GitSavvy.tests.mockito import unstub, when
 
 from GitSavvy.core.commands.log_graph import (
     GsLogGraphCurrentBranch,
     GsLogGraphRefreshCommand,
-    GsLogGraphCursorListener
+    GsLogGraphCursorListener,
+    extract_commit_hash
 )
 from GitSavvy.core.commands.show_commit_info import GsShowCommitInfoCommand
 from GitSavvy.core.settings import GitSavvySettings
@@ -32,6 +34,71 @@ COMMIT_2 = 'This is commit f461ea1'
 def fixture(name):
     with open(os.path.join(THIS_DIRNAME, 'fixtures', name)) as f:
         return f.read()
+
+
+EXTRACT_COMMIT_HASH_FIXTURE = r"""
+* 1948764 (HEAD -> master) f
+| *-.   3fe5938 (master_merge) Merge branches 'one' and 'two' into master_merge
+| |\ \
+|/ / /
+| | * 0a8f459 (two) ccc
+| | * 2084353 c
+| | * 006bcdd c
+* | | f8ceeb0 d
+| |/
+|/|
+| | *   9b42732 (refs/stash) On one: a
+| | |\
+| |/ /
+| | * c12cffd index on one: c3bba58 bb
+| |/
+| * c3bba58 (one) bb
+| * 18fd299 aa
+|/
+* fe67af3 b
+* 5e42cd1 a
+● | |   3c2e064 (tag: 2.17.4) Merge pull request #983 from divmain/release/2.17.4          (6 months ago) <Randy Lai>
+|\ \ \
+| ● \ \   b0d95ed Merge pull request #988 from divmain/help_text               (6 months ago) <Simon>
+| |\ \ \
+| | ● | | f950461 Fix: help_text will be stripped                              (6 months ago) <Randy Lai>
+| | | ● 6df205d (fork/diff-view-refreshes, diff-view-refreshes) Expect failures on Linux Travis
+""".strip().split('\n')
+HASHES = r"""
+1948764
+3fe5938
+
+
+0a8f459
+2084353
+006bcdd
+f8ceeb0
+
+
+9b42732
+
+
+c12cffd
+
+c3bba58
+18fd299
+
+fe67af3
+5e42cd1
+3c2e064
+
+b0d95ed
+
+f950461
+6df205d
+""".strip().split('\n')
+
+
+class TestDiffViewCommitHashExtraction(DeferrableTestCase):
+    @p.expand(list(zip(EXTRACT_COMMIT_HASH_FIXTURE, HASHES)))
+    def test_extract_commit_hash_from_line(self, line, expected):
+        actual = extract_commit_hash(line)
+        self.assertEqual(actual, expected)
 
 
 class TestDiffViewInteractionWithCommitInfoPanel(DeferrableTestCase):


### PR DESCRIPTION
For merges is totally possible that we get '\\' chars at the right of the '*'.

Added tests.

