### PR TITLE
Mostly accurate jumping from diff to file

### DIFF
--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -567,10 +567,6 @@ class GsDiffStageOrResetHunkCommand(TextCommand, GitCommand):
         self.view.run_command("gs_diff_refresh")
 
 
-HUNKS_LINES_RE = re.compile(r'@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? ')
-HEADER_TO_FILE_RE = re.compile(r'\+\+\+ b/(.+)$')
-
-
 class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
 
     """
@@ -703,6 +699,9 @@ def real_rowcol_in_hunk(hunk, relative_rowcol):
         return line.b, 1
 
 
+HUNKS_LINES_RE = re.compile(r'@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? ')
+
+
 def split_hunk(hunk):
     # type: (str) -> Optional[List[HunkLine]]
     """Split a hunk into (first char, line content, row) tuples
@@ -735,6 +734,9 @@ def _recount_lines(lines, b):
 def line_indentation(line):
     # type: (str) -> int
     return len(line) - len(line.lstrip())
+
+
+HEADER_TO_FILE_RE = re.compile(r'\+\+\+ b/(.+)$')
 
 
 def extract_filename_from_header(header):

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -668,6 +668,7 @@ def real_rowcol_in_hunk(hunk, relative_rowcol):
             for index, (first_char, _, _) in enumerate(hunk_lines, 1)
             if first_char in ('+', '-')
         )
+        col = 1
 
     first_char, line, b = hunk_lines[row_in_hunk - 1]
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -661,12 +661,15 @@ def real_rowcol_in_hunk(hunk, relative_rowcol):
     row_in_hunk, col = relative_rowcol
 
     # If the user is on the header line ('@@ ..') pretend to be on the
-    # first changed line instead.
+    # first visible line with some content instead.
     if row_in_hunk == 0:
         row_in_hunk = next(
-            index
-            for index, (first_char, _, _) in enumerate(hunk_lines, 1)
-            if first_char in ('+', '-')
+            (
+                index
+                for index, (first_char, line, _) in enumerate(hunk_lines, 1)
+                if first_char in ('+', ' ') and line.strip()
+            ),
+            1
         )
         col = 1
 

--- a/core/commands/diff.py
+++ b/core/commands/diff.py
@@ -627,12 +627,13 @@ class GsDiffOpenFileAtHunkCommand(TextCommand, GitCommand):
         if not head_and_hunk_offsets:
             return None
 
+        view = self.view
         header_region, hunk_region = head_and_hunk_offsets
-        header = self.view.substr(sublime.Region(*header_region))
-        hunk = self.view.substr(sublime.Region(*hunk_region))
+        header = extract_content(view, header_region)
+        hunk = extract_content(view, hunk_region)
         hunk_start, _ = hunk_region
 
-        rowcol = real_rowcol_in_hunk(hunk, relative_rowcol_in_hunk(self.view, hunk_start, pt))
+        rowcol = real_rowcol_in_hunk(hunk, relative_rowcol_in_hunk(view, hunk_start, pt))
         if not rowcol:
             return None
 

--- a/core/commands/show_commit.py
+++ b/core/commands/show_commit.py
@@ -72,15 +72,20 @@ class GsShowCommitOpenFileAtHunkCommand(GsDiffOpenFileAtHunkCommand):
     and open the file at that hunk in a separate view.
     """
 
-    def load_file_at_line(self, filename, lineno):
+    def load_file_at_line(self, filename, row, col):
+        # type: (str, int, int) -> None
         """
         Show file at target commit if `git_savvy.diff_view.target_commit` is non-empty.
         Otherwise, open the file directly.
         """
         commit_hash = self.view.settings().get("git_savvy.show_commit_view.commit")
         full_path = os.path.join(self.repo_path, filename)
-        self.view.window().run_command("gs_show_file_at_commit", {
+        window = self.view.window()
+        if not window:
+            return
+
+        window.run_command("gs_show_file_at_commit", {
             "commit_hash": commit_hash,
             "filepath": full_path,
-            "lineno": lineno
+            "lineno": row
         })

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -231,6 +231,103 @@ diff --git a/barz b/fooz
         self.assertEqual(actual, expected)
 
 
+class TestDiffViewJumpingToFile(DeferrableTestCase):
+    @classmethod
+    def setUpClass(cls):
+        sublime.run_command("new_window")
+        cls.window = sublime.active_window()
+        s = sublime.load_settings("Preferences.sublime-settings")
+        s.set("close_windows_when_empty", False)
+
+    @classmethod
+    def tearDownClass(self):
+        self.window.run_command('close_window')
+
+    def tearDown(self):
+        unstub()
+
+    @p.expand([
+        (79, ('barz', 16, 1)),
+        (80, ('barz', 16, 1)),
+        (81, ('barz', 16, 2)),
+
+        (85, ('barz', 17, 1)),
+        (86, ('barz', 17, 2)),
+
+        # on a '-' try to select next '+' line
+        (111, ('barz', 20, 1)),  # jump to 'four'
+
+        (209, ('boox', 17, 1)),  # jump to 'thr'
+        (210, ('boox', 17, 2)),
+        (211, ('boox', 17, 3)),
+        (212, ('boox', 17, 4)),
+        (213, ('boox', 17, 1)),
+        (214, ('boox', 17, 1)),
+
+        (223, ('boox', 19, 1)),  # all jump to 'sev'
+        (228, ('boox', 19, 1)),
+        (233, ('boox', 19, 1)),
+
+        (272, ('boox', 25, 5)),
+        (280, ('boox', 25, 5)),
+
+        (319, ('boox', 30, 1)),  # but do not jump if indentation does not match
+
+        # cursor on the hunk info line selects first diff line
+        (58, ('barz', 17, 1)),
+        (89, ('barz', 20, 1)),
+    ])
+    def test_a(self, CURSOR, EXPECTED):
+        VIEW_CONTENT = """\
+prelude
+--
+diff --git a/fooz b/barz
+--- a/fooz
++++ b/barz
+@@ -16,1 +16,1 @@ Hi
+ one
++two
+@@ -20,1 +20,1 @@ Ho
+-three
+ context
++four
+diff --git a/foxx b/boxx
+--- a/foox
++++ b/boox
+@@ -16,1 +16,1 @@ Hello
+ one
+-two
++thr
+ fou
+-fiv
+-six
++sev
+ eig
+@@ -24 +24 @@ Hello
+     one
+-    two
+     thr
+@@ -30 +30 @@ Hello
+     one
+-    two
+ thr
+"""
+        view = self.window.new_file()
+        self.addCleanup(view.close)
+        view.run_command('append', {'characters': VIEW_CONTENT})
+        view.set_scratch(True)
+
+        cmd = module.GsDiffOpenFileAtHunkCommand(view)
+        when(cmd).load_file_at_line(...)
+
+        view.sel().clear()
+        view.sel().add(CURSOR)
+
+        cmd.run({'unused_edit'})
+
+        verify(cmd).load_file_at_line(*EXPECTED)
+
+
 class TestDiffViewHunking(DeferrableTestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_diff_view.py
+++ b/tests/test_diff_view.py
@@ -274,7 +274,8 @@ class TestDiffViewJumpingToFile(DeferrableTestCase):
         (319, ('boox', 30, 1)),  # but do not jump if indentation does not match
 
         # cursor on the hunk info line selects first diff line
-        (58, ('barz', 17, 1)),
+        (58, ('barz', 16, 1)),
+        (59, ('barz', 16, 1)),
         (89, ('barz', 20, 1)),
     ])
     def test_a(self, CURSOR, EXPECTED):


### PR DESCRIPTION
Jumping from diff to file really was super sloppy implemented. It almost never jumped to the correct position. 

Implements mostly accurate jumping from diff to file by actually
parsing the hunk and recounting its lines.

For lines which are present on the b side (the view we jump to) this
is accurate of course. For deleted lines ('-') we, mildly arbitrary,
have to choose a good enough line.

If the user is not within a hunk, jump to the first visible line with content. 