### PR TITLE
Fix: defensive tab cycle

### DIFF
--- a/core/interfaces/__init__.py
+++ b/core/interfaces/__init__.py
@@ -33,11 +33,12 @@ class GsTabCycleCommand(TextCommand, GitCommand):
             return
         view_signature = self.view_signatures[to_load]
 
-        self.view.window().run_command("hide_panel", {"cancel": True})
-
-        self.view.window().run_command(self.commands[to_load])
-        if not self.view.settings().get(view_signature):
-            sublime.set_timeout_async(self.view.close)
+        window = self.view.window()
+        if window:
+            window.run_command("hide_panel", {"cancel": True})
+            window.run_command(self.commands[to_load])
+            if not self.view.settings().get(view_signature):
+                sublime.set_timeout_async(self.view.close)
 
     def get_next(self, source, reverse=False):
         tab_order = self.savvy_settings.get("tab_order")


### PR DESCRIPTION
If window is closed / reopened the command may trigger the exception:
    
    Traceback (most recent call last):
      File "/Users/pavel.savchenko/Library/Application Support/Sublime Text 3/Packages/GitSavvy/core/interfaces/__init__.py", line 28, in <lambda>
        sublime.set_timeout_async(lambda: self.run_async(source, target, reverse))
      File "/Users/pavel.savchenko/Library/Application Support/Sublime Text 3/Packages/GitSavvy/core/interfaces/__init__.py", line 36, in run_async
        self.view.window().run_command("hide_panel", {"cancel": True})
    AttributeError: 'NoneType' object has no attribute 'run_command'