### PR TITLE
Skip inline diff wording when > 10 000 hunk

### DIFF
--- a/common/util/diff_string.py
+++ b/common/util/diff_string.py
@@ -28,6 +28,13 @@ def get_indices(chunks):
 
 
 def get_changes(old, new):
+    # if one of the inputs, either old or new is more then 10 000  characters
+    # we skip tring to find the words which changed. If a hunk is more than
+    # 10 000 charachers it is most likly a generated change.
+    # We skip since this calculation take a lot of time then it gets bigger.
+    if max(len(old), len(new)) > 10000:
+        return []
+
     old_chunks = tuple(filter(lambda x: x, boundary.split(old)))
     new_chunks = tuple(filter(lambda x: x, boundary.split(new)))
     old_indices = get_indices(old_chunks)

--- a/core/commands/inline_diff.py
+++ b/core/commands/inline_diff.py
@@ -145,6 +145,9 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
     """
 
     def run(self, edit):
+        sublime.set_timeout_async(self.run_async, 0)
+
+    def run_async(self):
         file_path = self.file_path
         in_cached_mode = self.view.settings().get("git_savvy.inline_diff_view.in_cached_mode")
         ignore_eol_arg = (
@@ -181,7 +184,10 @@ class GsInlineDiffRefreshCommand(TextCommand, GitCommand):
             row, col = self.view.rowcol(cursors[0].begin())
 
         self.view.set_read_only(False)
-        self.view.replace(edit, sublime.Region(0, self.view.size()), inline_diff_contents)
+        self.view.run_command("gs_replace_view_text", {
+            "text": inline_diff_contents,
+            "restore_cursors": True,
+        })
 
         if cursors:
             if (row, col) == (0, 0) and self.savvy_settings.get("inline_diff_auto_scroll", False):


### PR DESCRIPTION
fix: #1133 

@kaste, This is't perfect but it helps. The `SequenceMatcher.get_opcodes` call is the slow one in this case When I run it on a file with 30000 charachets with one characher changes it takes 35 sec om my mac book pro. We could "solve" by backgrounding. I dont think is it worst the CPU time even. 

If you want to source controll a 30000 character long line manually please split it up. I also this SequenceMatcher uses more time it the are move changes between the lines.

An onther solution would be to use gits --word-diff. SequenceMatcher does a better job at finding the excat characher which changes. Git word-diff is a lot faster but less exact.

ok, fix? 