### PR TITLE
Misc: fix travis linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: required
 
 env:


### PR DESCRIPTION
As per discussion here: https://github.com/travis-ci/travis-ci/issues/9133#issuecomment-506211772 , seems travis-ci switched Ubuntu build images to Xenial (16.06) by default, which does not ship with Python 3.3. So we had failures such as [this one][1].

Related docs:
- https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments
- https://blog.travis-ci.com/2018-11-08-xenial-release
- https://docs.travis-ci.com/user/reference/xenial/

[1]: https://travis-ci.org/divmain/GitSavvy/builds/547753063