### PR TITLE
Do not offer merge against self

### DIFF
--- a/core/commands/merge.py
+++ b/core/commands/merge.py
@@ -20,7 +20,7 @@ class GsMergeCommand(WindowCommand, GitCommand):
     def run_async(self):
         show_branch_panel(
             self.on_branch_selection,
-            selected_branch=False)
+            ignore_current_branch=True)
 
     def on_branch_selection(self, branch):
         if not branch:


### PR DESCRIPTION
The command `git: merge` should imo not show the branch currently checked out.