### PR TITLE
Fixup graph view

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -205,6 +205,9 @@ class GsLogGraphCursorListener(EventListener, GitCommand):
         if not window:
             return
 
+        if view not in window.views():
+            return
+
         panel_view = window.find_output_panel('show_commit_info')
         if not panel_view:
             return

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -341,15 +341,18 @@ class GsLogGraphActionCommand(GsLogActionCommand):
         view = self.window.active_view()
 
         self.selections = view.sel()
+        if not len(self.selections) == 1:
+            self.window.status_message("You can only do actions on one commit at a time.")
+            return
 
         lines = util.view.get_lines_from_regions(view, self.selections)
         line = lines[0]
 
-        self._commit_hash = extract_commit_hash(line)
-        self._file_path = self.file_path
-
-        if not len(self.selections) == 1:
-            self.window.status_message("You can only do actions on one commit at a time.")
+        commit_hash = extract_commit_hash(line)
+        if not commit_hash:
             return
+
+        self._commit_hash = commit_hash
+        self._file_path = self.file_path
 
         super().run(commit_hash=self._commit_hash, file_path=self._file_path)


### PR DESCRIPTION
Two fixes, two commits:

1. On `<enter>` the action panel should only open if the cursor is actually on a line with a commit. (E.g. not on one the decorated lines in-between)

2. On `<enter>` should immediately open a panl even if the commit detail bottom panel is currently open. The current behavior is that on first `<enter>` the detail panels closes, then you have to press `<enter>` a second time to actually open the action panel. 

