### PR TITLE
Fix: Add `file_path` for graph current file

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -98,6 +98,10 @@ class GsLogGraphRefreshCommand(TextCommand, GitCommand):
         if branch:
             args.append(branch)
 
+        if self.file_path:
+            file_path = self.get_rel_path(self.file_path)
+            args = args + ["--", file_path]
+
         return args
 
 


### PR DESCRIPTION
The command graph current file is currently broken bc the actual file_path is not added to the command. So this is a simple fix, but an embarrassing bug. 