### PR TITLE
Remember last log and graph pre-select action

### DIFF
--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -128,6 +128,7 @@ class GsLogByBranchCommand(LogMixin, WindowCommand, GitCommand):
 
 
 class GsLogCommand(PanelCommandMixin, WindowCommand, GitCommand):
+    selected_index = 0
     default_actions = [
         ["gs_log_current_branch", "For current branch"],
         ["gs_log_all_branches", "For all branches"],

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -109,6 +109,7 @@ class GsLogGraphCommand(GsLogCommand):
     ensures that each of the defined actions/commands in `default_actions` are finally
     called with `file_path` set.
     """
+    selected_index = 0
     default_actions = [
         ["gs_log_graph_current_branch", "For current branch"],
         ["gs_log_graph_all_branches", "For all branches"],


### PR DESCRIPTION
Remember the last main(?) action, e.g. 'log all branches' etc.

We do this independently for log and graph_log maybe bc I like graph for all branches, but log for the current branch. It would be probably even better if we remembered the default actions for the 'current_file' variants as well bc graph current file is usually best with current branch. I could add that.