### PR TITLE
Remember last branch used by log filter by branch

### DIFF
--- a/core/commands/log.py
+++ b/core/commands/log.py
@@ -118,12 +118,17 @@ class GsLogByAuthorCommand(LogMixin, WindowCommand, GitCommand):
 
 
 class GsLogByBranchCommand(LogMixin, WindowCommand, GitCommand):
+    _selected_branch = None
 
     def run_async(self, **kwargs):
-        show_branch_panel(lambda branch: self.on_branch_selection(branch, **kwargs))
+        show_branch_panel(
+            lambda branch: self.on_branch_selection(branch, **kwargs),
+            selected_branch=self._selected_branch
+        )
 
     def on_branch_selection(self, branch, **kwargs):
         if branch:
+            self._selected_branch = branch
             super().run_async(branch=branch, **kwargs)
 
 

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -167,9 +167,10 @@ class GsLogGraphByAuthorCommand(LogGraphMixin, WindowCommand, GitCommand):
 
 
 class GsLogGraphByBranchCommand(LogGraphMixin, WindowCommand, GitCommand):
+    _selected_branch = None
 
     def run_async(self):
-        show_branch_panel(self.on_branch_selection)
+        show_branch_panel(self.on_branch_selection, selected_branch=self._selected_branch)
 
     def on_branch_selection(self, branch):
         if branch:


### PR DESCRIPTION
Log as well as graph log can "filter by branch". With this PR the last used branch will be remembered. 