### PR TITLE
Simplify `GsLogGraphActionCommand`

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1397,7 +1397,7 @@
 
     {
         "keys": ["enter"],
-        "command": "gs_log_graph_action",
+        "command": "gs_compare_commit_action",
         "context": [
             { "key": "setting.git_savvy.compare_commit_view", "operator": "equal", "operand": true }
         ]

--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -306,37 +306,7 @@ class GsLogGraphToggleMoreInfoCommand(TextCommand, WindowCommand, GitCommand):
         draw_info_panel(self.view, show_panel)
 
 
-class GsLogGraphActionCommand(GsLogActionCommand):
-
-    """
-    Define menu shown if you `<enter>` on a specific commit.
-    Also used by `compare_commit_view`.
-    """
-    default_actions = [
-        ["show_commit", "Show commit"],
-        ["checkout_commit", "Checkout commit"],
-        ["cherry_pick", "Cherry-pick commit"],
-        ["compare_against", "Compare commit against ..."],
-        ["copy_sha", "Copy the full SHA"]
-    ]
-
-    def update_actions(self):
-        super().update_actions()  # GsLogActionCommand will mutate actions if `_file_path` is set!
-        view = self.window.active_view()
-        if view.settings().get("git_savvy.log_graph_view"):
-            if self._file_path:
-                # for `git: graph current file`
-                self.actions.insert(5, ["revert_commit", "Revert commit"])
-            else:
-                self.actions.insert(3, ["revert_commit", "Revert commit"])
-
-            self.actions.extend([
-                ["diff_commit", "Diff commit"],
-                ["diff_commit_cache", "Diff commit (cached)"],
-            ])
-        elif view.settings().get("git_savvy.compare_commit_view"):
-            pass
-
+class GraphActionMixin(GsLogActionCommand):
     def run(self):
         view = self.window.active_view()
 
@@ -353,3 +323,17 @@ class GsLogGraphActionCommand(GsLogActionCommand):
             return
 
         super().run(commit_hash=self._commit_hash, file_path=self._file_path)
+
+
+class GsCompareCommitActionCommand(GraphActionMixin):
+    default_actions = [
+        ["show_commit", "Show commit"],
+        ["checkout_commit", "Checkout commit"],
+        ["cherry_pick", "Cherry-pick commit"],
+        ["compare_against", "Compare commit against ..."],
+        ["copy_sha", "Copy the full SHA"]
+    ]
+
+
+class GsLogGraphActionCommand(GraphActionMixin):
+    ...


### PR DESCRIPTION
Actually `GsLogGraphActionCommand` should show the same actions as the base
`GsLogActionCommand`, and the compare commit view is the invariant here.

This is more DRY in that I expect that the actions I can take on a commit should be the same regardless of me using the log panel or the graph interface. E.g. if we add an action here it should up everywhere.
