### PR TITLE
Fix: Git clone URL in README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     include:
         - name: Linux
           os: linux
+          dist: trusty
           language: python
           python: 3.3
         - name: OSX

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ cd $HOME/.config/sublime-text-3/Packages
 # on Windows (PowerShell)
 cd "$env:appdata\Sublime Text 3\Packages\"
 
-git clone git@github.com/divmain/GitSavvy.git
+git clone https://github.com/divmain/GitSavvy.git
 
 # Package Control need to be installed https://packagecontrol.io/installation
 # install dependencies from command line


### PR DESCRIPTION
Previous URL was missing colon:
```
fatal: repository 'git@github.com/divmain/GitSavvy.git' does not exist
```

Opted for the https URL because it is the default given by Github.
