### PR TITLE
Change the length of the commit messages

### DIFF
--- a/GitSavvy.sublime-settings
+++ b/GitSavvy.sublime-settings
@@ -149,7 +149,7 @@
     "pedantic_commit": true,
     "pedantic_commit_ruler": true,
     "pedantic_commit_first_line_length": 50,
-    "pedantic_commit_message_line_length": 80,
+    "pedantic_commit_message_line_length": 72,
     "pedantic_commit_warning_length": 20,
 
     /*

--- a/core/commands/commit.py
+++ b/core/commands/commit.py
@@ -11,25 +11,27 @@ from ..exceptions import GitSavvyError
 
 
 COMMIT_HELP_TEXT_EXTRA = """##
-## You may also reference or close a GitHub issue with this commit.  To do so,
-## type `#` followed by the `tab` key.  You will be shown a list of issues
-## related to the current repo.  You may also type `owner/repo#` plus the `tab`
-## key to reference an issue in a different GitHub repo.
+## You may also reference or close a GitHub issue with this commit.
+## To do so, type `#` followed by the `tab` key.  You will be shown a
+## list of issues related to the current repo.  You may also type
+## `owner/repo#` plus the `tab` key to reference an issue in a
+## different GitHub repo.
 
 """
 
 COMMIT_HELP_TEXT_ALT = """
 
-## To make a commit, type your commit message and close the window. To cancel
-## the commit, delete the commit message and close the window. To sign off on
-## the commit, press {key}-S.
+## To make a commit, type your commit message and close the window.
+## To cancel the commit, delete the commit message and close the window.
+## To sign off on the commit, press {key}-S.
 """.format(key=util.super_key) + COMMIT_HELP_TEXT_EXTRA
 
 
 COMMIT_HELP_TEXT = """
 
-## To make a commit, type your commit message and press {key}-ENTER. To cancel
-## the commit, close the window. To sign off on the commit, press {key}-S.
+## To make a commit, type your commit message and press {key}-ENTER.
+## To cancel the commit, close the window. To sign off on the commit,
+## press {key}-S.
 """.format(key=util.super_key) + COMMIT_HELP_TEXT_EXTRA
 
 COMMIT_SIGN_TEXT = """


### PR DESCRIPTION
Hey! 

I just think that the default commit message length should be 72, as it's stated in the git guidelines here: 

>Capitalized, short (50 chars or less) summary

>More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines

Therefore messages for commit command should be also 72 so they don't exceed the character limit and are marked in red. 

I guess this is a hotfix, change it if you think otherwise. 