### PR TITLE
Fix: `disable_logging` should reset to previous state

### DIFF
--- a/common/util/debug.py
+++ b/common/util/debug.py
@@ -32,11 +32,12 @@ def stop_logging():
 @contextmanager
 def disable_logging():
     global enabled
+    previous_state = enabled
     enabled = False
     try:
         yield
     finally:
-        enabled = True
+        enabled = previous_state
 
 
 def get_log():


### PR DESCRIPTION
The `disable_logging` context manager sets `enabled=True` on exit which is obviously not what we want. We need to restore the previous state.

