### PR TITLE
Do not mark obvious parent in graph view

### DIFF
--- a/core/commands/log_graph.py
+++ b/core/commands/log_graph.py
@@ -338,7 +338,12 @@ def _colorize_dots(vid, dots):
     # type: (sublime.ViewId, Tuple[colorizer.Char]) -> None
     view = sublime.View(vid)
     view.add_regions('gs_log_graph_dot', [d.region() for d in dots], scope=DOT_SCOPE)
-    paths = [c.region() for d in dots for c in colorizer.follow_path(d)]
+    paths = [
+        c.region()
+        for path in map(colorizer.follow_path, dots)
+        if len(path) > 1
+        for c in path
+    ]
     view.add_regions('gs_log_graph_follow_path', paths, scope=PATH_SCOPE)
 
 

--- a/core/commands/log_graph_colorizer.py
+++ b/core/commands/log_graph_colorizer.py
@@ -2,7 +2,7 @@ import sublime
 
 MYPY = False
 if MYPY:
-    from typing import Callable, Dict, Iterator, Tuple, TypeVar
+    from typing import Callable, Dict, Iterator, List, Tuple, TypeVar
 
     T = TypeVar('T')
 
@@ -155,12 +155,17 @@ def handles(ch):
 
 
 def follow_path(dot):
+    # type: (Char) -> List[Char]
+    return list(_follow_path(dot))
+
+
+def _follow_path(dot):
     # type: (Char) -> Iterator[Char]
     for c in follow_char(dot):
         # print('{} -> {}'.format(dot, c))
         yield c
         if c != COMMIT_NODE_CHAR:
-            yield from follow_path(c)
+            yield from _follow_path(c)
 
 
 def follow_char(char):


### PR DESCRIPTION
If the selected commit has only a parent right below, do not colorize
it for less visual noise.

T.i. in such cases of consecutive commits there is no 'path' to the parent so I think we should omit colorizing like so: 

![image](https://user-images.githubusercontent.com/8558/66217611-ed8f9080-e6c7-11e9-823b-e5341772ef4c.png)

Compare to current dev:

![image](https://user-images.githubusercontent.com/8558/66217692-10ba4000-e6c8-11e9-8d05-1ff03f96c648.png)

WDYT?
